### PR TITLE
Align stage 1 manifest descriptions with wrapper scripts

### DIFF
--- a/skillsets/index.json
+++ b/skillsets/index.json
@@ -10,7 +10,7 @@
         "skill": "wm-research",
         "prerequisite_gate": "resources/index.md",
         "produces_gate": "brief.agreed.md",
-        "description": "Stage 1: Research and brief agreed"
+        "description": "Stage 1: Project brief agreed"
       },
       {
         "order": 2,
@@ -80,7 +80,7 @@
         "skill": "bmc-research",
         "prerequisite_gate": "resources/index.md",
         "produces_gate": "brief.agreed.md",
-        "description": "Project brief agreed"
+        "description": "Stage 1: Project brief agreed"
       },
       {
         "order": 2,


### PR DESCRIPTION
## Summary

- WM stage 1 manifest said "Research and brief agreed" but the script emits "Project brief agreed"
- BMC stage 1 manifest said "Project brief agreed" (missing "Stage 1:" prefix every other stage has)
- Both mismatches break `GetProjectProgressUseCase` which matches decision titles against manifest descriptions

Two-line fix in `skillsets/index.json`.