### PR TITLE
Add citation verification step to org-research

### DIFF
--- a/org-research/SKILL.md
+++ b/org-research/SKILL.md
@@ -140,7 +140,14 @@ After all sub-reports are complete, write `resources/index.md`:
    - Where technology or market evolution is happening
    - What constraints (regulatory, contractual, technical) exist
 5. Cross-reference sub-reports but do not duplicate their detail
-6. Include a manifest listing each sub-report, its date, and confidence
+6. **Verify citation density** before producing the gate artifact:
+   - Every factual claim in every sub-report must have an inline
+     citation with a URL
+   - Each sub-report must reference at least 3 distinct sources
+   - If any sub-report falls below this threshold, return to it and
+     add citations before proceeding. Do not produce the gate artifact
+     with uncited claims.
+7. Include a manifest listing each sub-report, its date, and confidence
 
 After each sub-report is written, register it in the structured manifest:
 ```


### PR DESCRIPTION
## Summary

- Add citation density verification as step 6 in the Synthesis procedure
- Every factual claim requires inline citation with URL
- Each sub-report must reference at least 3 distinct sources
- Gate artifact blocked until citation threshold met

This is the skill-level fix for #4. A domain-level fix (structured research entities) is blocked by the bounded context architecture (#29).

Closes #4

## Test plan

- [ ] Verify step numbering is correct in Synthesis section
- [ ] Read through for coherence with sub-report format requirements