### PR TITLE
Add draft cleanup to wm-needs agreement flow

### DIFF
--- a/wm-needs/SKILL.md
+++ b/wm-needs/SKILL.md
@@ -122,7 +122,16 @@ Based on client feedback:
 3. Ask the client to confirm: "Is this needs document now accurate
    and complete enough to proceed?"
 
-When the client agrees:
+When the client agrees, clean up superseded drafts before writing the
+gate artifact:
+1. Compare files in `needs/drafts/` against the agreed user classes
+2. Move any draft that does not correspond to an agreed user class
+   to `needs/drafts/archive/` (merges, renames, and abandoned classes
+   all produce superseded drafts)
+3. The `needs/drafts/` directory should contain exactly one file per
+   agreed user class
+
+Then write the gate artifact:
 1. Copy `needs/needs.md` to `needs/needs.agreed.md`
 2. Record the agreement:
    ```


### PR DESCRIPTION
## Summary

- After client agrees on user classes, archive drafts that don't correspond to agreed classes
- Superseded drafts (from merges, renames, abandoned classes) move to `needs/drafts/archive/`
- Draft directory stays consistent with agreed output

Closes #15

## Test plan

- [ ] Verify cleanup step sits correctly between "client agrees" and gate artifact writing
- [ ] Read through for coherence with existing iteration flow