### PR TITLE
Remove atlas/tour vocabulary from generic practice docs

### DIFF
--- a/docs/deliverable-architecture.md
+++ b/docs/deliverable-architecture.md
@@ -20,15 +20,18 @@ ProjectContribution
 ├── overview_md: str
 └── sections: list[ProjectSection]
     ├── pages: list[ContentPage]        # flat pages (e.g. Analysis)
-    ├── groups: list[PageGroup]         # categorised index (e.g. Atlas)
-    └── tours: list[TourPageContent]    # curated presentations
+    └── groups: list[PageGroup]         # categorised index (e.g. Atlas)
 ```
 
 Every project produces sections. A project with just a brief gets
 `sections=[ProjectSection(label="Analysis", pages=[brief_page])]`. A
-project with everything gets three sections (Presentations, Atlas,
-Analysis). There is no flat vs three-tier mode detection — just "show
-what exists."
+project with everything gets multiple sections. There is no flat vs
+multi-section mode detection — just "show what exists."
+
+How a skillset organises its sections is its own concern. The WM
+presenter produces Presentations, Atlas, and Analysis sections. The
+BMC presenter produces an Analysis section. The generic layer sees
+only `ProjectSection` containing pages and groups.
 
 ### Key entities
 
@@ -36,14 +39,13 @@ what exists."
 |--------|---------|
 | `Figure` | SVG content with optional caption |
 | `ContentPage` | A single page of prose + optional figures |
-| `PageGroup` | A labelled collection of pages (atlas category) |
-| `TourStopContent` | One assembled tour stop with figures and analysis |
-| `TourGroupContent` | Related stops plus transition prose |
-| `TourPageContent` | Complete tour: opening, groups, metadata |
+| `PageGroup` | A labelled collection of pages |
 | `ProjectSection` | A major section within a project |
 | `ProjectContribution` | Everything a project contributes to the deliverable |
 
-All entities are defined in `bin/cli/entities.py`.
+Generic content entities are defined in `bin/cli/content.py`.
+Skillset-specific content types (e.g. WM tour assembly structures)
+live behind the relevant presenter.
 
 ## Protocol boundary
 
@@ -61,9 +63,13 @@ class ProjectPresenter(Protocol):
     def present(
         self,
         project: Project,
-        tours: list[TourManifest],
+        research_topics: list[ResearchTopic],
     ) -> ProjectContribution: ...
 ```
+
+Each presenter fetches whatever skillset-specific data it needs from
+its own repositories. The generic protocol passes only lifecycle data
+that any presenter might use.
 
 ### SiteRenderer
 
@@ -114,7 +120,7 @@ class NewSkillsetPresenter:
     def present(
         self,
         project: Project,
-        tours: list[TourManifest],
+        research_topics: list[ResearchTopic],
     ) -> ProjectContribution:
         proj_dir = self._ws_root / project.client / "projects" / project.slug
         # Read workspace files, assemble sections

--- a/docs/semantic-waist.md
+++ b/docs/semantic-waist.md
@@ -47,7 +47,7 @@ chain," "this is the strategy."
   /      \  WAIST /      \  WAIST /      \  WAIST /      \
  /        \/     /        \/     /        \/     /        \
 
- research   needs    chain    evolve   strategy   atlas/tours
+ research   needs    chain    evolve   strategy   deliverable
 ```
 
 The `===` marks are the semantic waist: narrow points where diffuse
@@ -62,7 +62,7 @@ architecture:
 
 ```
 entities.py      Domain objects: Project, DecisionEntry, EngagementEntry,
-                 ResearchTopic, TourManifest, Skillset, PipelineStage
+                 ResearchTopic, Skillset, PipelineStage
 
 repositories.py  Protocols: how entities are stored and retrieved
                  (no implementation details, just contracts)
@@ -137,9 +137,11 @@ stage, completed stages, and next prerequisite. This is the concentrated
 output of potentially weeks of engagement work, available in
 milliseconds.
 
-When the site renderer builds the deliverable site, it reads projects,
-tours, and research topics through repository queries. It does not parse
-a single markdown artifact to determine project structure.
+When the site renderer builds the deliverable site, it reads projects
+and research topics through repository queries, then delegates to
+per-skillset presenters that assemble workspace artifacts into generic
+content entities. It does not parse markdown artifacts to determine
+project structure.
 
 When the `review` skill inventories what happened during an engagement,
 it reads the decision log and engagement log — complete audit trails in
@@ -211,9 +213,11 @@ it means the operation costs zero tokens.
 
 Because the waist is the single source of truth for engagement state,
 skills that have never heard of each other can compose. A future
-business plan skill can read the project registry, decision logs,
-and tour manifests to understand what analytical work has been done —
-without knowing anything about Wardley Mapping or BMC internals.
+business plan skill can read the project registry and decision logs to
+understand what analytical work has been done — without knowing anything
+about Wardley Mapping or BMC internals. Skillset-specific content
+(atlas views, tour presentations, canvas blocks) stays behind
+per-skillset presenter boundaries.
 
 The waist is the API between skills. Each skill writes its convergent
 conclusions into it. Each skill reads its preconditions from it.


### PR DESCRIPTION
## Summary

Preparatory documentation cleanup for #41 (push atlas/tour behind WM presenter boundary).

- **semantic-waist.md**: Remove `TourManifest` from generic entity list, replace "atlas/tours" in diamond diagram with "deliverable", update site renderer description to reference per-skillset presenters, note skillset-specific content stays behind presenter boundaries
- **deliverable-architecture.md**: Remove `TourPageContent` from `ProjectSection` diagram, remove tour content types from key entities table, update `ProjectPresenter` protocol signature to post-#41 form, update new-skillset example, note section organisation is each skillset's concern

These doc changes reflect the design decision that atlas/tour concepts belong in `wardley_mapping/`, not in the generic practice layer (see comment on #29).

## Test plan

- [x] Read both docs end-to-end for coherence
- [x] Verify no remaining generic references to tour/atlas vocabulary