### PR TITLE
Design generic EntityStore[T] protocol

### DIFF
--- a/bin/cli/infrastructure/json_entity_store.py
+++ b/bin/cli/infrastructure/json_entity_store.py
@@ -1,0 +1,117 @@
+"""Generic JSON-backed EntityStore implementation.
+
+Configurable for any Pydantic entity type stored as a JSON array.
+Path resolution, key field, and save semantics are injected at
+construction time.  One class replaces JsonProjectRepository,
+JsonDecisionRepository, JsonEngagementRepository,
+JsonResearchTopicRepository, and JsonSkillsetRepository.
+
+TourManifestRepository uses JSON objects (not arrays) with directory
+scanning, so it needs a separate implementation variant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import Enum
+from pathlib import Path
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+from bin.cli.infrastructure.json_store import JsonArrayStore
+
+T = TypeVar("T", bound=BaseModel)
+
+PathResolver = Callable[[dict[str, str]], Path]
+
+
+class JsonEntityStore(Generic[T]):
+    """EntityStore backed by JSON array files.
+
+    Constructor parameters:
+        model: The Pydantic model class for deserialization.
+        key_field: The entity field used as identity within a file
+            (e.g. "slug" for Project, "id" for DecisionEntry).
+        path_resolver: Maps a filters dict to the JSON file path.
+            Only scope-relevant keys need to be present; extra keys
+            are ignored by the resolver but still applied as entity
+            filters.
+        append_only: When True, save appends rather than upserts.
+            Matches current behaviour for DecisionEntry and
+            EngagementEntry.
+    """
+
+    def __init__(
+        self,
+        model: type[T],
+        key_field: str,
+        path_resolver: PathResolver,
+        *,
+        append_only: bool = False,
+    ) -> None:
+        self._store = JsonArrayStore(model, key_field)
+        self._model = model
+        self._key_field = key_field
+        self._resolve_path = path_resolver
+        self._append_only = append_only
+
+    def get(self, filters: dict[str, str]) -> T | None:
+        path = self._resolve_path(filters)
+        for item in self._store.load(path):
+            if _matches(item, filters):
+                return item
+        return None
+
+    def search(self, filters: dict[str, str] | None = None) -> list[T]:
+        filters = filters or {}
+        path = self._resolve_path(filters)
+        items = self._store.load(path)
+        if not filters:
+            return items
+        return [item for item in items if _matches(item, filters)]
+
+    def save(self, entity: T) -> None:
+        scope = _string_fields(entity)
+        path = self._resolve_path(scope)
+        if self._append_only:
+            self._store.append(path, entity)
+        else:
+            self._store.upsert(path, entity)
+
+    def delete(self, filters: dict[str, str]) -> bool:
+        path = self._resolve_path(filters)
+        items = self._store.load(path)
+        remaining = [item for item in items if not _matches(item, filters)]
+        if len(remaining) == len(items):
+            return False
+        self._store.persist(path, remaining)
+        return True
+
+
+def _matches(entity: BaseModel, filters: dict[str, str]) -> bool:
+    """Check whether an entity matches all filter key-value pairs.
+
+    Comparison uses ``==`` which works for plain strings and for
+    str-based enums (``ProjectStatus.PLANNING == "planning"``).
+    """
+    for field, value in filters.items():
+        attr = getattr(entity, field, None)
+        if attr is None:
+            return False
+        if isinstance(attr, Enum):
+            if attr.value != value:
+                return False
+        elif attr != value:
+            return False
+    return True
+
+
+def _string_fields(entity: BaseModel) -> dict[str, str]:
+    """Extract string-valued fields from an entity for path resolution."""
+    result: dict[str, str] = {}
+    for field_name in entity.model_fields:
+        val = getattr(entity, field_name)
+        if isinstance(val, str):
+            result[field_name] = val
+    return result

--- a/bin/cli/store.py
+++ b/bin/cli/store.py
@@ -1,0 +1,116 @@
+"""Generic entity store protocol.
+
+Replaces six entity-specific repository protocols with a single
+generic interface. Designed for #44; part of the #29 target
+architecture.
+
+All identity and scoping is expressed through string-keyed filters.
+Entities carry their own identity and scope fields, so save(entity)
+is self-contained.
+
+Filter values are always strings. Enum fields compare naturally
+because all domain enums extend str (str, Enum).
+
+Mapping from current repository protocols
+==========================================
+
+SkillsetRepository -> EntityStore[Skillset]
+-------------------------------------------
+  get(name)                -> get({"name": name})
+  list_all()               -> search()
+
+ProjectRepository -> EntityStore[Project]
+-----------------------------------------
+  get(client, slug)        -> get({"client": client, "slug": slug})
+  list_all(client)         -> search({"client": client})
+  list_filtered(client,    -> search({"client": client,
+    skillset, status)            "skillset": skillset,
+                                 "status": status.value})
+  save(project)            -> save(project)
+  delete(client, slug)     -> delete({"client": client, "slug": slug})
+  client_exists(client)    -> usecase logic: search({"client": client}) != []
+
+DecisionRepository -> EntityStore[DecisionEntry]
+------------------------------------------------
+  get(client, project_slug, id) -> get({"client": client,
+                                        "project_slug": project_slug,
+                                        "id": id})
+  list_all(client, project_slug) -> search({"client": client,
+                                            "project_slug": project_slug})
+  list_filtered(client,          -> search({"client": client,
+    project_slug, title)                    "project_slug": project_slug,
+                                            "title": title})
+  save(entry)                    -> save(entry)
+
+EngagementRepository -> EntityStore[EngagementEntry]
+----------------------------------------------------
+  get(client, id)          -> get({"client": client, "id": id})
+  list_all(client)         -> search({"client": client})
+  save(entry)              -> save(entry)
+
+ResearchTopicRepository -> EntityStore[ResearchTopic]
+-----------------------------------------------------
+  get(client, filename)    -> get({"client": client, "filename": filename})
+  list_all(client)         -> search({"client": client})
+  save(topic)              -> save(topic)
+  exists(client, filename) -> usecase logic: get({...}) is not None
+
+TourManifestRepository -> EntityStore[TourManifest]
+---------------------------------------------------
+  get(client, project_slug,  -> get({"client": client,
+    tour_name)                       "project_slug": project_slug,
+                                     "name": tour_name})
+  list_all(client,           -> search({"client": client,
+    project_slug)                      "project_slug": project_slug})
+  save(manifest)             -> save(manifest)
+
+Specialized methods removed
+===========================
+  client_exists  -> usecase queries engagement store
+  exists         -> usecase calls get() and checks for None
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar, runtime_checkable
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel, covariant=True)
+
+
+@runtime_checkable
+class EntityStore(Protocol[T]):
+    """Generic store for domain entities.
+
+    Single protocol replacing all entity-specific repositories.
+    Scoping and identity are expressed through string-keyed filters.
+    Immutability is a usecase concern, not a store concern.
+    """
+
+    def get(self, filters: dict[str, str]) -> T | None:
+        """Retrieve a single entity matching all filters.
+
+        Returns None if no match.
+        """
+        ...
+
+    def search(self, filters: dict[str, str] | None = None) -> list[T]:
+        """List entities matching all filters.
+
+        None or empty filters returns all entities in the store's
+        scope. Each filter is a field-name to string-value pair.
+        """
+        ...
+
+    def save(self, entity: T) -> None:
+        """Save an entity (create or update).
+
+        The entity carries its own identity and scope. Save semantics
+        (upsert vs append) are an implementation detail.
+        """
+        ...
+
+    def delete(self, filters: dict[str, str]) -> bool:
+        """Delete entity matching filters. Returns True if deleted."""
+        ...

--- a/tests/test_entity_store.py
+++ b/tests/test_entity_store.py
@@ -1,0 +1,259 @@
+"""EntityStore proof — Project reimplemented against the generic protocol.
+
+Demonstrates that JsonEntityStore[Project] covers every operation
+currently served by JsonProjectRepository, validating the generic
+protocol design from #44.
+
+Each test maps to a specific TestProjectContract test, showing the
+old API call and its EntityStore equivalent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bin.cli.entities import Project, ProjectStatus
+from bin.cli.infrastructure.json_entity_store import JsonEntityStore
+from bin.cli.store import EntityStore
+
+from .conftest import make_project
+
+
+def _project_store(workspace_root: Path) -> JsonEntityStore[Project]:
+    """Factory matching JsonProjectRepository's path layout."""
+    return JsonEntityStore(
+        model=Project,
+        key_field="slug",
+        path_resolver=lambda f: workspace_root
+        / f["client"]
+        / "projects"
+        / "index.json",
+    )
+
+
+@pytest.fixture
+def store(tmp_path) -> JsonEntityStore[Project]:
+    return _project_store(tmp_path / "clients")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    """JsonEntityStore satisfies the EntityStore protocol."""
+
+    def test_is_entity_store(self, store):
+        assert isinstance(store, EntityStore)
+
+
+# ---------------------------------------------------------------------------
+# get — replaces ProjectRepository.get(client, slug)
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    def test_missing_returns_none(self, store):
+        # Was: project_repo.get("holloway-group", "nonexistent")
+        assert store.get({"client": "holloway-group", "slug": "nonexistent"}) is None
+
+    def test_save_then_get(self, store):
+        # Was: project_repo.save(p); project_repo.get("holloway-group", "maps-1")
+        store.save(make_project())
+        got = store.get({"client": "holloway-group", "slug": "maps-1"})
+        assert got is not None
+        assert got.slug == "maps-1"
+        assert got.skillset == "wardley-mapping"
+
+    def test_wrong_slug_returns_none(self, store):
+        store.save(make_project(slug="maps-1"))
+        assert store.get({"client": "holloway-group", "slug": "maps-2"}) is None
+
+
+# ---------------------------------------------------------------------------
+# search — replaces list_all(client) and list_filtered(client, ...)
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_empty_scope_returns_empty(self, store):
+        # Was: project_repo.list_all("holloway-group")
+        assert store.search({"client": "holloway-group"}) == []
+
+    def test_list_all_by_scope(self, store):
+        store.save(make_project(slug="maps-1"))
+        store.save(make_project(slug="maps-2"))
+        assert len(store.search({"client": "holloway-group"})) == 2
+
+    def test_filter_by_skillset(self, store):
+        # Was: project_repo.list_filtered("holloway-group", skillset="wardley-mapping")
+        store.save(make_project(slug="maps-1", skillset="wardley-mapping"))
+        store.save(make_project(slug="canvas-1", skillset="business-model-canvas"))
+        result = store.search(
+            {"client": "holloway-group", "skillset": "wardley-mapping"}
+        )
+        assert len(result) == 1
+        assert result[0].slug == "maps-1"
+
+    def test_filter_by_status(self, store):
+        # Was: project_repo.list_filtered("holloway-group", status=ProjectStatus.ELABORATION)
+        store.save(make_project(slug="maps-1", status=ProjectStatus.PLANNING))
+        store.save(make_project(slug="maps-2", status=ProjectStatus.ELABORATION))
+        result = store.search({"client": "holloway-group", "status": "elaboration"})
+        assert len(result) == 1
+        assert result[0].slug == "maps-2"
+
+    def test_filter_no_match(self, store):
+        store.save(make_project(status=ProjectStatus.PLANNING))
+        result = store.search({"client": "holloway-group", "status": "implementation"})
+        assert result == []
+
+    def test_no_filters_beyond_scope_returns_all(self, store):
+        # Was: project_repo.list_filtered("holloway-group") with no optional args
+        store.save(make_project(slug="maps-1"))
+        store.save(make_project(slug="maps-2"))
+        assert len(store.search({"client": "holloway-group"})) == 2
+
+    def test_combined_filters(self, store):
+        store.save(
+            make_project(
+                slug="maps-1",
+                skillset="wardley-mapping",
+                status=ProjectStatus.PLANNING,
+            )
+        )
+        store.save(
+            make_project(
+                slug="maps-2",
+                skillset="wardley-mapping",
+                status=ProjectStatus.ELABORATION,
+            )
+        )
+        result = store.search(
+            {
+                "client": "holloway-group",
+                "skillset": "wardley-mapping",
+                "status": "planning",
+            }
+        )
+        assert len(result) == 1
+        assert result[0].slug == "maps-1"
+
+
+# ---------------------------------------------------------------------------
+# save — replaces ProjectRepository.save(project)
+# ---------------------------------------------------------------------------
+
+
+class TestSave:
+    def test_upsert_updates_existing(self, store):
+        # Was: save twice with same slug, different status
+        store.save(make_project(status=ProjectStatus.PLANNING))
+        store.save(make_project(status=ProjectStatus.ELABORATION))
+        got = store.get({"client": "holloway-group", "slug": "maps-1"})
+        assert got.status == ProjectStatus.ELABORATION
+        assert len(store.search({"client": "holloway-group"})) == 1
+
+
+# ---------------------------------------------------------------------------
+# delete — replaces ProjectRepository.delete(client, slug)
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_delete_existing(self, store):
+        store.save(make_project())
+        assert store.delete({"client": "holloway-group", "slug": "maps-1"}) is True
+        assert store.get({"client": "holloway-group", "slug": "maps-1"}) is None
+
+    def test_delete_missing(self, store):
+        assert store.delete({"client": "holloway-group", "slug": "nope"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Scoping — replaces client isolation and client_exists
+# ---------------------------------------------------------------------------
+
+
+class TestScoping:
+    def test_client_isolation(self, store):
+        store.save(make_project(client="holloway-group"))
+        store.save(make_project(client="meridian-health"))
+        assert len(store.search({"client": "holloway-group"})) == 1
+        assert len(store.search({"client": "meridian-health"})) == 1
+
+    def test_client_exists_as_usecase_logic(self, store):
+        # Was: project_repo.client_exists("holloway-group")
+        # Now: usecase checks search result
+        assert store.search({"client": "holloway-group"}) == []
+        store.save(make_project())
+        assert store.search({"client": "holloway-group"}) != []
+
+
+# ---------------------------------------------------------------------------
+# Decision proof — append-only store with project scoping
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionProof:
+    """Verify the append_only flag works for immutable entity patterns."""
+
+    @pytest.fixture
+    def decision_store(self, tmp_path):
+        from bin.cli.entities import DecisionEntry
+
+        return JsonEntityStore(
+            model=DecisionEntry,
+            key_field="id",
+            path_resolver=lambda f: (
+                tmp_path
+                / "clients"
+                / f["client"]
+                / "projects"
+                / f["project_slug"]
+                / "decisions.json"
+            ),
+            append_only=True,
+        )
+
+    def test_append_creates_separate_entries(self, decision_store):
+        from .conftest import make_decision
+
+        decision_store.save(make_decision(id="d1", title="Stage 1"))
+        decision_store.save(make_decision(id="d2", title="Stage 2"))
+        result = decision_store.search(
+            {"client": "holloway-group", "project_slug": "maps-1"}
+        )
+        assert len(result) == 2
+
+    def test_search_by_title(self, decision_store):
+        from .conftest import make_decision
+
+        decision_store.save(make_decision(id="d1", title="Stage 1: Research agreed"))
+        decision_store.save(make_decision(id="d2", title="Stage 2: Needs agreed"))
+        result = decision_store.search(
+            {
+                "client": "holloway-group",
+                "project_slug": "maps-1",
+                "title": "Stage 1: Research agreed",
+            }
+        )
+        assert len(result) == 1
+        assert result[0].id == "d1"
+
+    def test_project_isolation(self, decision_store):
+        from .conftest import make_decision
+
+        decision_store.save(make_decision(id="d1", project_slug="maps-1"))
+        decision_store.save(make_decision(id="d2", project_slug="maps-2"))
+        assert (
+            len(
+                decision_store.search(
+                    {"client": "holloway-group", "project_slug": "maps-1"}
+                )
+            )
+            == 1
+        )


### PR DESCRIPTION
## Summary

- Adds `EntityStore[T]` protocol in `bin/cli/store.py` — single generic interface replacing all six entity-specific repository protocols
- Adds `JsonEntityStore[T]` in `bin/cli/infrastructure/json_entity_store.py` — configurable JSON implementation supporting both upsert and append-only semantics
- Adds proof tests in `tests/test_entity_store.py` covering Project (full CRUD with enum filters, client isolation, scoping-as-usecase-logic) and DecisionEntry (append-only with project scoping)

## Design decisions

- **Filter values are strings.** All domain enums are `(str, Enum)` so `entity.status == "planning"` works natively. No union type needed at the protocol boundary.
- **Single CRUD protocol.** Immutability is a usecase concern, not a store concern. Append-only behaviour is an implementation flag (`append_only=True`).
- **Scoping is a filter problem.** `client`, `project_slug` etc. are just filter keys. The path resolver uses them for file location; the matcher applies them for correctness.
- **`client_exists` and `exists` become usecase logic.** `search({"client": c}) != []` replaces `client_exists(c)`. `get({...}) is not None` replaces `exists()`.

## Mapping analysis

Full mapping table in the `store.py` module docstring showing how every method on all six current protocols translates to the generic interface.

Addresses #44.

## Test plan

- [x] 19 new proof tests pass
- [x] All 233 existing tests pass
- [x] ruff check + format clean
- [x] doctrine conformance tests pass