### PR TITLE
Ensure research skills register projects in JSON store

### DIFF
--- a/bmc-research/SKILL.md
+++ b/bmc-research/SKILL.md
@@ -85,14 +85,22 @@ This is a negotiation. The client may:
 Iterate until the client confirms.
 
 When the client agrees:
-1. Create the project directory:
+1. If the project is not yet registered (i.e. `engage` was not run
+   first), register it now:
+   ```
+   engage/scripts/register-project.sh --client {org} --slug {slug} \
+     --skillset "business-model-canvas" --scope "{agreed scope}"
+   ```
+   If the project already exists in the registry (engage created it),
+   skip this step.
+2. Create the project directory (if not already created by engage):
    ```
    projects/{slug}/
    └── segments/
        └── drafts/
    ```
-2. Write `brief.agreed.md` with the agreed scope
-3. Record the brief agreement and activate the project:
+3. Write `brief.agreed.md` with the agreed scope
+4. Record the brief agreement and activate the project:
    ```
    bmc-research/scripts/record-brief-agreed.sh --client {org} --project {slug} \
      --field "Scope={agreed scope}" --field "Focus areas={list}"

--- a/wm-research/SKILL.md
+++ b/wm-research/SKILL.md
@@ -107,7 +107,15 @@ This is a negotiation. The client may:
 Iterate until the client confirms.
 
 When the client agrees:
-1. Create the project directory:
+1. If the project is not yet registered (i.e. `engage` was not run
+   first), register it now:
+   ```
+   engage/scripts/register-project.sh --client {org} --slug {slug} \
+     --skillset "wardley-mapping" --scope "{agreed scope}"
+   ```
+   If the project already exists in the registry (engage created it),
+   skip this step.
+2. Create the project directory (if not already created by engage):
    ```
    projects/{slug}/
    ├── needs/
@@ -119,8 +127,8 @@ When the client agrees:
    └── strategy/
        └── plays/
    ```
-2. Write `brief.agreed.md` with the agreed scope
-3. Record the brief agreement and activate the project:
+3. Write `brief.agreed.md` with the agreed scope
+4. Record the brief agreement and activate the project:
    ```
    wm-research/scripts/record-brief-agreed.sh --client {org} --project {slug} \
      --field "Scope={agreed scope}" --field "Primary users={list}"


### PR DESCRIPTION
## Summary

- wm-research and bmc-research allow creating projects directly (bypassing engage), but their `record-brief-agreed.sh` scripts call `decision record` and `project update-status` — both of which require the project to already exist in `projects/index.json`
- Add a project registration step (via `engage/scripts/register-project.sh`) before recording the brief agreement, so bypassing engage no longer leaves an unregistered project
- This was the root cause of the duckitandrun site rendering incomplete — projects existed as workspace directories but were never in the JSON store the renderer reads

## Test plan

- [x] Verify `wm-research/SKILL.md` includes registration step before `record-brief-agreed.sh`
- [x] Verify `bmc-research/SKILL.md` includes registration step before `record-brief-agreed.sh`
- [ ] Run a new project through wm-research without engage and confirm JSON store is populated