### PR TITLE
Tidy up before bounded context packaging

### DIFF
--- a/bin/cli/infrastructure/json_entity_store.py
+++ b/bin/cli/infrastructure/json_entity_store.py
@@ -110,7 +110,7 @@ def _matches(entity: BaseModel, filters: dict[str, str]) -> bool:
 def _string_fields(entity: BaseModel) -> dict[str, str]:
     """Extract string-valued fields from an entity for path resolution."""
     result: dict[str, str] = {}
-    for field_name in entity.model_fields:
+    for field_name in type(entity).model_fields:
         val = getattr(entity, field_name)
         if isinstance(val, str):
             result[field_name] = val

--- a/src/practice/repositories.py
+++ b/src/practice/repositories.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from practice.content import ProjectContribution
 
 if TYPE_CHECKING:
+    # TODO(#47): Move to consulting.entities when bounded contexts land.
     from bin.cli.entities import Project, ResearchTopic
 
 


### PR DESCRIPTION
## Summary

- Fix Pydantic deprecation: access `model_fields` on the class, not the instance — silences 32 warnings per test run
- Mark the `practice.repositories` backward reference to `bin.cli.entities` with `TODO(#47)` for the migration

Prep for #47. No behavior change.