### PR TITLE
Move shared entities to practice/ package

### DIFF
--- a/bin/cli/dtos.py
+++ b/bin/cli/dtos.py
@@ -12,11 +12,12 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-from bin.cli.entities import Confidence, ProjectStatus
 from bin.cli.wm_types import TourStop
+from practice.entities import Confidence, ProjectStatus
 
 if TYPE_CHECKING:
-    from bin.cli.entities import DecisionEntry, Project, ResearchTopic
+    from bin.cli.entities import DecisionEntry
+    from practice.entities import Project, ResearchTopic
 
 
 # ---------------------------------------------------------------------------

--- a/bin/cli/entities.py
+++ b/bin/cli/entities.py
@@ -1,8 +1,11 @@
-"""Domain entities for consulting practice accounting operations.
+"""Lifecycle entities for consulting practice accounting.
 
-Entities carry identity and scoping context so that repository
-save(entity) calls are self-contained. Skillsets are first-class
-entities discovered from manifests at runtime, not hardcoded enums.
+Shared domain entities (Project, ProjectStatus, Confidence,
+ResearchTopic, Skillset) live in practice.entities — they appear
+in protocol signatures that cross bounded context boundaries.
+
+This module holds lifecycle-only entities that will move to the
+consulting bounded context in a future PR.
 
 Domain exceptions live in practice.exceptions.
 Deliverable content entities live in practice.content.
@@ -12,70 +15,8 @@ PipelineStage lives in practice.discovery.
 from __future__ import annotations
 
 from datetime import date, datetime
-from enum import Enum
 
 from pydantic import BaseModel
-
-from practice.discovery import PipelineStage
-
-
-# ---------------------------------------------------------------------------
-# Skillset entities (discovered from skillsets/*.md manifests)
-# ---------------------------------------------------------------------------
-
-
-class Skillset(BaseModel):
-    """A consulting product line. Discovered from skillsets/*.md."""
-
-    name: str
-    display_name: str
-    description: str
-    pipeline: list[PipelineStage]
-    slug_pattern: str
-
-
-# ---------------------------------------------------------------------------
-# Practice entities
-# ---------------------------------------------------------------------------
-
-
-class ProjectStatus(str, Enum):
-    """Lifecycle phase of a consulting project.
-
-    The lifecycle is linear:
-    planning → elaboration → implementation → review → closed.
-    Each label describes the project's phase, not the operator's activity.
-    """
-
-    PLANNING = "planning"
-    ELABORATION = "elaboration"
-    IMPLEMENTATION = "implementation"
-    REVIEW = "review"
-    CLOSED = "closed"
-
-    def next(self) -> ProjectStatus | None:
-        """Return the next lifecycle phase, or None if terminal."""
-        members = list(ProjectStatus)
-        idx = members.index(self)
-        return members[idx + 1] if idx + 1 < len(members) else None
-
-
-class Confidence(str, Enum):
-    HIGH = "High"
-    MEDIUM_HIGH = "Medium-High"
-    MEDIUM = "Medium"
-    LOW = "Low"
-
-
-class Project(BaseModel):
-    """A single consulting project within a client engagement."""
-
-    slug: str
-    client: str
-    skillset: str
-    status: ProjectStatus
-    created: date
-    notes: str = ""
 
 
 class DecisionEntry(BaseModel):
@@ -107,13 +48,3 @@ class EngagementEntry(BaseModel):
     timestamp: datetime
     title: str
     fields: dict[str, str]
-
-
-class ResearchTopic(BaseModel):
-    """A completed research topic in the client's research manifest."""
-
-    filename: str
-    client: str
-    topic: str
-    date: date
-    confidence: Confidence

--- a/bin/cli/infrastructure/bmc_presenter.py
+++ b/bin/cli/infrastructure/bmc_presenter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from practice.content import ContentPage, ProjectContribution, ProjectSection
-from bin.cli.entities import Project
+from practice.entities import Project
 
 
 def _read_md(path: Path) -> str:

--- a/bin/cli/infrastructure/jinja_renderer.py
+++ b/bin/cli/infrastructure/jinja_renderer.py
@@ -17,7 +17,7 @@ from jinja2 import Environment, FileSystemLoader
 from markupsafe import Markup
 
 from practice.content import Figure, NarrativePage, ProjectContribution, ProjectSection
-from bin.cli.entities import ResearchTopic
+from practice.entities import ResearchTopic
 
 
 # ---------------------------------------------------------------------------

--- a/bin/cli/infrastructure/json_repos.py
+++ b/bin/cli/infrastructure/json_repos.py
@@ -28,14 +28,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from bin.cli.entities import (
-    DecisionEntry,
-    EngagementEntry,
-    Project,
-    ProjectStatus,
-    ResearchTopic,
-    Skillset,
-)
+from bin.cli.entities import DecisionEntry, EngagementEntry
+from practice.entities import Project, ProjectStatus, ResearchTopic, Skillset
 from bin.cli.wm_types import TourManifest
 from bin.cli.infrastructure.json_store import (
     JsonArrayStore,

--- a/bin/cli/infrastructure/wardley_presenter.py
+++ b/bin/cli/infrastructure/wardley_presenter.py
@@ -21,7 +21,7 @@ from practice.content import (
     ProjectContribution,
     ProjectSection,
 )
-from bin.cli.entities import Project
+from practice.entities import Project
 from bin.cli.wm_types import TourManifest, TourManifestRepository
 
 

--- a/bin/cli/repositories.py
+++ b/bin/cli/repositories.py
@@ -18,14 +18,8 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from bin.cli.entities import (
-    DecisionEntry,
-    EngagementEntry,
-    Project,
-    ProjectStatus,
-    ResearchTopic,
-    Skillset,
-)
+from bin.cli.entities import DecisionEntry, EngagementEntry
+from practice.entities import Project, ProjectStatus, ResearchTopic, Skillset
 
 
 # ---------------------------------------------------------------------------

--- a/bin/cli/usecases.py
+++ b/bin/cli/usecases.py
@@ -39,14 +39,8 @@ from bin.cli.dtos import (
     UpdateProjectStatusRequest,
     UpdateProjectStatusResponse,
 )
-from bin.cli.entities import (
-    Confidence,
-    DecisionEntry,
-    EngagementEntry,
-    Project,
-    ProjectStatus,
-    ResearchTopic,
-)
+from bin.cli.entities import DecisionEntry, EngagementEntry
+from practice.entities import Confidence, Project, ProjectStatus, ResearchTopic
 from bin.cli.wm_types import TourManifest, TourManifestRepository
 from practice.exceptions import DuplicateError, InvalidTransitionError, NotFoundError
 from practice.repositories import Clock, IdGenerator, ProjectPresenter, SiteRenderer

--- a/src/practice/__init__.py
+++ b/src/practice/__init__.py
@@ -2,6 +2,6 @@
 
 This package defines the contract surface that bounded contexts depend on:
 protocols for persistence, presentation, rendering, and infrastructure
-services, plus the content entities and domain exceptions shared across
-all skillsets.
+services, plus the shared domain entities, content entities, and domain
+exceptions used across all skillsets.
 """

--- a/src/practice/entities.py
+++ b/src/practice/entities.py
@@ -1,0 +1,92 @@
+"""Shared domain entities referenced by practice-layer protocols.
+
+Entities that appear in protocol signatures in this package are shared
+vocabulary across all bounded contexts. They live here — not in any
+single BC — so that dependency direction flows downward.
+
+Lifecycle-only entities (DecisionEntry, EngagementEntry) belong in
+their bounded context, not here.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+
+from pydantic import BaseModel
+
+from practice.discovery import PipelineStage
+
+
+# ---------------------------------------------------------------------------
+# Skillset (discovery vocabulary — every BC declares these)
+# ---------------------------------------------------------------------------
+
+
+class Skillset(BaseModel):
+    """A consulting product line. Discovered from skillsets/*.md."""
+
+    name: str
+    display_name: str
+    description: str
+    pipeline: list[PipelineStage]
+    slug_pattern: str
+
+
+# ---------------------------------------------------------------------------
+# Project (shared — appears in ProjectPresenter.present() signature)
+# ---------------------------------------------------------------------------
+
+
+class ProjectStatus(str, Enum):
+    """Lifecycle phase of a consulting project.
+
+    The lifecycle is linear:
+    planning → elaboration → implementation → review → closed.
+    Each label describes the project's phase, not the operator's activity.
+    """
+
+    PLANNING = "planning"
+    ELABORATION = "elaboration"
+    IMPLEMENTATION = "implementation"
+    REVIEW = "review"
+    CLOSED = "closed"
+
+    def next(self) -> ProjectStatus | None:
+        """Return the next lifecycle phase, or None if terminal."""
+        members = list(ProjectStatus)
+        idx = members.index(self)
+        return members[idx + 1] if idx + 1 < len(members) else None
+
+
+class Confidence(str, Enum):
+    HIGH = "High"
+    MEDIUM_HIGH = "Medium-High"
+    MEDIUM = "Medium"
+    LOW = "Low"
+
+
+class Project(BaseModel):
+    """A single consulting project within a client engagement."""
+
+    slug: str
+    client: str
+    skillset: str
+    status: ProjectStatus
+    created: date
+    notes: str = ""
+
+
+# ---------------------------------------------------------------------------
+# ResearchTopic (shared — appears in SiteRenderer.render() signature)
+# ---------------------------------------------------------------------------
+
+
+class ResearchTopic(BaseModel):
+    """A completed research topic in the client's research manifest."""
+
+    filename: str
+    client: str
+    topic: str
+    date: date
+    confidence: Confidence

--- a/src/practice/repositories.py
+++ b/src/practice/repositories.py
@@ -8,13 +8,10 @@ from __future__ import annotations
 
 from datetime import date, datetime, tzinfo
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from practice.content import ProjectContribution
-
-if TYPE_CHECKING:
-    # TODO(#47): Move to consulting.entities when bounded contexts land.
-    from bin.cli.entities import Project, ResearchTopic
+from practice.entities import Project, ResearchTopic
 
 
 @runtime_checkable
@@ -58,7 +55,7 @@ class ProjectPresenter(Protocol):
 
     def present(
         self,
-        project: "Project",
+        project: Project,
     ) -> ProjectContribution: ...
 
 
@@ -76,7 +73,7 @@ class SiteRenderer(Protocol):
         self,
         client: str,
         contributions: list[ProjectContribution],
-        research_topics: list["ResearchTopic"],
+        research_topics: list[ResearchTopic],
     ) -> Path:
         """Render a static site for a client. Returns the output directory."""
         ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,10 @@ import pytest
 
 from bin.cli.config import Config
 from bin.cli.di import Container
-from bin.cli.entities import (
+from bin.cli.entities import DecisionEntry, EngagementEntry
+from practice.discovery import PipelineStage
+from practice.entities import (
     Confidence,
-    DecisionEntry,
-    EngagementEntry,
-    PipelineStage,
     Project,
     ProjectStatus,
     ResearchTopic,

--- a/tests/test_bmc_presenter.py
+++ b/tests/test_bmc_presenter.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from bin.cli.entities import Project, ProjectStatus
+from practice.entities import Project, ProjectStatus
 from bin.cli.infrastructure.bmc_presenter import BmcProjectPresenter
 
 CLIENT = "test-corp"

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -28,11 +28,8 @@ from bin.cli.dtos import (
     RecordDecisionRequest,
     RegisterProjectRequest,
 )
-from bin.cli.entities import (
-    PipelineStage,
-    Project,
-    ProjectStatus,
-)
+from practice.discovery import PipelineStage
+from practice.entities import Project, ProjectStatus
 from bin.cli.infrastructure.bmc_presenter import BmcProjectPresenter
 from bin.cli.infrastructure.json_repos import JsonTourManifestRepository
 from bin.cli.infrastructure.wardley_presenter import WardleyProjectPresenter

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -12,11 +12,9 @@ from datetime import date
 
 import pytest
 
-from bin.cli.entities import (
-    DecisionEntry,
-    PipelineStage,
-    ProjectStatus,
-)
+from bin.cli.entities import DecisionEntry
+from practice.discovery import PipelineStage
+from practice.entities import ProjectStatus
 
 from .conftest import (
     make_decision,

--- a/tests/test_entity_store.py
+++ b/tests/test_entity_store.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from bin.cli.entities import ProjectStatus
+from practice.entities import ProjectStatus
 from practice.store import EntityStore
 
 from .conftest import make_decision, make_project

--- a/tests/test_repository_contracts.py
+++ b/tests/test_repository_contracts.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 
-from bin.cli.entities import Confidence, ProjectStatus
+from practice.entities import Confidence, ProjectStatus
 
 from .conftest import (
     make_decision,

--- a/tests/test_wardley_presenter.py
+++ b/tests/test_wardley_presenter.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from bin.cli.entities import Project, ProjectStatus
+from practice.entities import Project, ProjectStatus
 from bin.cli.wm_types import TourManifest, TourStop
 from bin.cli.infrastructure.json_repos import JsonTourManifestRepository
 from bin.cli.infrastructure.wardley_presenter import WardleyProjectPresenter


### PR DESCRIPTION
## Summary

- Create `practice/entities.py` with `Project`, `ProjectStatus`, `Confidence`, `ResearchTopic`, `Skillset` — entities that appear in `practice/` protocol signatures
- Slim `bin/cli/entities.py` to lifecycle-only entities (`DecisionEntry`, `EngagementEntry`)
- Replace `TYPE_CHECKING` hack in `practice/repositories.py` with direct imports from `practice.entities`
- Update 17 import sites across production and test code

## Why

`practice/repositories.py` had an upward dependency:

```python
if TYPE_CHECKING:
    from bin.cli.entities import Project, ResearchTopic
```

The shared library was looking up into the application layer. This violates the dependency rule for #47 (bounded context packaging) where `practice/` is the foundation that all BCs depend on — it cannot import from any BC or from `bin/cli/`.

The fix: entities that appear in `practice/` protocol signatures are shared vocabulary and live in `practice/`. After this PR, `practice/` has zero imports from `bin/cli/` at any level.

## Verification

- `ruff check .` — all checks passed
- `ruff format --check .` — 40 files formatted
- `pytest -m doctrine` — 66 passed
- `pytest` — 303 passed

## Context

PR 1 of 6 for #47 (bounded context packaging).