### PR TITLE
Move CLI command registration into bounded contexts

### DIFF
--- a/bin/cli/main.py
+++ b/bin/cli/main.py
@@ -1,9 +1,9 @@
 """CLI entry point for consulting practice accounting operations.
 
-Thin application shell: parse arguments, compose a request DTO,
-execute the usecase, format the response. No business logic lives here.
+Thin application shell: create CLI group, discover bounded context
+commands, keep cross-BC commands (site). No business logic lives here.
 
-Invocation: uv run consultamatron <group> <command> [options]
+Invocation: uv run practice <group> <command> [options]
 """
 
 from __future__ import annotations
@@ -16,21 +16,10 @@ import click
 from bin.cli.config import Config
 from bin.cli.di import Container
 from bin.cli.dtos import RenderSiteRequest
-from wardley_mapping.dtos import RegisterTourRequest
-from consulting.dtos import (
-    AddEngagementEntryRequest,
-    GetProjectProgressRequest,
-    GetProjectRequest,
-    InitializeWorkspaceRequest,
-    ListDecisionsRequest,
-    ListProjectsRequest,
-    ListResearchTopicsRequest,
-    RecordDecisionRequest,
-    RegisterProjectRequest,
-    RegisterResearchTopicRequest,
-    UpdateProjectStatusRequest,
-)
 from bin.cli.introspect import generate_command
+
+import consulting.cli
+import wardley_mapping.cli
 
 
 @click.group()
@@ -40,269 +29,14 @@ def cli(ctx: click.Context) -> None:
     ctx.obj = Container(Config.from_repo_root(Path.cwd()))
 
 
-# ---------------------------------------------------------------------------
-# project
-# ---------------------------------------------------------------------------
+# -- Register bounded context commands -------------------------------------
 
-
-@cli.group()
-def project() -> None:
-    """Manage consulting projects."""
-
-
-def _format_init_workspace(resp: Any) -> None:
-    click.echo(f"Initialized workspace for '{resp.client}'")
-
-
-project.add_command(
-    generate_command(
-        name="init",
-        request_model=InitializeWorkspaceRequest,
-        usecase_attr="initialize_workspace_usecase",
-        format_output=_format_init_workspace,
-    )
-)
-
-
-def _format_register_project(resp: Any) -> None:
-    click.echo(
-        f"Registered project '{resp.slug}' ({resp.skillset}) for '{resp.client}'"
-    )
-
-
-project.add_command(
-    generate_command(
-        name="register",
-        request_model=RegisterProjectRequest,
-        usecase_attr="register_project_usecase",
-        format_output=_format_register_project,
-    )
-)
-
-
-def _format_update_status(resp: Any) -> None:
-    click.echo(f"Updated '{resp.project_slug}' status to '{resp.status}'")
-
-
-project.add_command(
-    generate_command(
-        name="update-status",
-        request_model=UpdateProjectStatusRequest,
-        usecase_attr="update_project_status_usecase",
-        format_output=_format_update_status,
-    )
-)
-
-
-def _format_list_projects(resp: Any) -> None:
-    if not resp.projects:
-        click.echo("No projects found.")
-        return
-    for p in resp.projects:
-        click.echo(f"  {p.slug}  {p.skillset}  {p.status}  {p.created}")
-
-
-project.add_command(
-    generate_command(
-        name="list",
-        request_model=ListProjectsRequest,
-        usecase_attr="list_projects_usecase",
-        format_output=_format_list_projects,
-    )
-)
-
-
-def _format_get_project(resp: Any) -> None:
-    if resp.project is None:
-        raise click.ClickException(f"Project '{resp.slug}' not found.")
-    p = resp.project
-    click.echo(f"Slug:     {p.slug}")
-    click.echo(f"Skillset: {p.skillset}")
-    click.echo(f"Status:   {p.status}")
-    click.echo(f"Created:  {p.created}")
-    if p.notes:
-        click.echo(f"Notes:    {p.notes}")
-
-
-project.add_command(
-    generate_command(
-        name="get",
-        request_model=GetProjectRequest,
-        usecase_attr="get_project_usecase",
-        format_output=_format_get_project,
-    )
-)
-
-
-def _format_project_progress(resp: Any) -> None:
-    if not resp.stages:
-        click.echo("No pipeline stages found.")
-        return
-    for s in resp.stages:
-        mark = "x" if s.completed else " "
-        click.echo(f"  [{mark}] {s.order}. {s.description} ({s.skill})")
-    if resp.current_stage:
-        click.echo(f"\nCurrent: {resp.current_stage}")
-    if resp.next_prerequisite:
-        click.echo(f"Next gate: {resp.next_prerequisite}")
-
-
-project.add_command(
-    generate_command(
-        name="progress",
-        request_model=GetProjectProgressRequest,
-        usecase_attr="get_project_progress_usecase",
-        format_output=_format_project_progress,
-    )
-)
+consulting.cli.register_commands(cli)
+wardley_mapping.cli.register_commands(cli)
 
 
 # ---------------------------------------------------------------------------
-# decision
-# ---------------------------------------------------------------------------
-
-
-@cli.group()
-def decision() -> None:
-    """Manage project decisions."""
-
-
-def _format_decision_record(resp: Any) -> None:
-    click.echo(
-        f"Recorded decision '{resp.title}' for "
-        f"'{resp.client}/{resp.project_slug}' ({resp.decision_id})"
-    )
-
-
-decision.add_command(
-    generate_command(
-        name="record",
-        request_model=RecordDecisionRequest,
-        usecase_attr="record_decision_usecase",
-        format_output=_format_decision_record,
-    )
-)
-
-
-def _format_decision_list(resp: Any) -> None:
-    if not resp.decisions:
-        click.echo("No decisions recorded.")
-        return
-    for d in resp.decisions:
-        click.echo(f"  {d.date}  {d.title}")
-        for k, v in d.fields.items():
-            click.echo(f"           {k}: {v}")
-
-
-decision.add_command(
-    generate_command(
-        name="list",
-        request_model=ListDecisionsRequest,
-        usecase_attr="list_decisions_usecase",
-        format_output=_format_decision_list,
-    )
-)
-
-
-# ---------------------------------------------------------------------------
-# engagement
-# ---------------------------------------------------------------------------
-
-
-@cli.group()
-def engagement() -> None:
-    """Manage client engagement history."""
-
-
-def _format_engagement_add(resp: Any) -> None:
-    click.echo(
-        f"Added engagement entry '{resp.title}' for '{resp.client}' ({resp.entry_id})"
-    )
-
-
-engagement.add_command(
-    generate_command(
-        name="add",
-        request_model=AddEngagementEntryRequest,
-        usecase_attr="add_engagement_entry_usecase",
-        format_output=_format_engagement_add,
-    )
-)
-
-
-# ---------------------------------------------------------------------------
-# research
-# ---------------------------------------------------------------------------
-
-
-@cli.group()
-def research() -> None:
-    """Manage research topics."""
-
-
-def _format_research_add(resp: Any) -> None:
-    click.echo(
-        f"Registered topic '{resp.topic}' as '{resp.filename}' for '{resp.client}'"
-    )
-
-
-research.add_command(
-    generate_command(
-        name="add",
-        request_model=RegisterResearchTopicRequest,
-        usecase_attr="register_research_topic_usecase",
-        format_output=_format_research_add,
-    )
-)
-
-
-def _format_research_list(resp: Any) -> None:
-    if not resp.topics:
-        click.echo("No research topics found.")
-        return
-    for t in resp.topics:
-        click.echo(f"  {t.filename}  {t.topic}  {t.confidence}  {t.date}")
-
-
-research.add_command(
-    generate_command(
-        name="list",
-        request_model=ListResearchTopicsRequest,
-        usecase_attr="list_research_topics_usecase",
-        format_output=_format_research_list,
-    )
-)
-
-
-# ---------------------------------------------------------------------------
-# tour
-# ---------------------------------------------------------------------------
-
-
-@cli.group()
-def tour() -> None:
-    """Manage presentation tours."""
-
-
-def _format_tour_register(resp: Any) -> None:
-    click.echo(
-        f"Registered tour '{resp.name}' with {resp.stop_count} stops "
-        f"for '{resp.client}/{resp.project_slug}'"
-    )
-
-
-tour.add_command(
-    generate_command(
-        name="register",
-        request_model=RegisterTourRequest,
-        usecase_attr="register_tour_usecase",
-        format_output=_format_tour_register,
-    )
-)
-
-
-# ---------------------------------------------------------------------------
-# site
+# site (cross-BC, stays here)
 # ---------------------------------------------------------------------------
 
 

--- a/bin/render-site.sh
+++ b/bin/render-site.sh
@@ -15,4 +15,4 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Extract client slug from path like "clients/duckitandrun/"
 CLIENT="$(basename "${1%/}")"
 
-exec uv run --project "$REPO_DIR" consultamatron site render --client "$CLIENT"
+exec uv run --project "$REPO_DIR" practice site render --client "$CLIENT"

--- a/consulting/cli.py
+++ b/consulting/cli.py
@@ -1,0 +1,239 @@
+"""CLI command registration for the consulting bounded context.
+
+Registers project, decision, engagement, and research command groups.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from bin.cli.introspect import generate_command
+from consulting.dtos import (
+    AddEngagementEntryRequest,
+    GetProjectProgressRequest,
+    GetProjectRequest,
+    InitializeWorkspaceRequest,
+    ListDecisionsRequest,
+    ListProjectsRequest,
+    ListResearchTopicsRequest,
+    RecordDecisionRequest,
+    RegisterProjectRequest,
+    RegisterResearchTopicRequest,
+    UpdateProjectStatusRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Format callbacks
+# ---------------------------------------------------------------------------
+
+
+def _format_init_workspace(resp: Any) -> None:
+    click.echo(f"Initialized workspace for '{resp.client}'")
+
+
+def _format_register_project(resp: Any) -> None:
+    click.echo(
+        f"Registered project '{resp.slug}' ({resp.skillset}) for '{resp.client}'"
+    )
+
+
+def _format_update_status(resp: Any) -> None:
+    click.echo(f"Updated '{resp.project_slug}' status to '{resp.status}'")
+
+
+def _format_list_projects(resp: Any) -> None:
+    if not resp.projects:
+        click.echo("No projects found.")
+        return
+    for p in resp.projects:
+        click.echo(f"  {p.slug}  {p.skillset}  {p.status}  {p.created}")
+
+
+def _format_get_project(resp: Any) -> None:
+    if resp.project is None:
+        raise click.ClickException(f"Project '{resp.slug}' not found.")
+    p = resp.project
+    click.echo(f"Slug:     {p.slug}")
+    click.echo(f"Skillset: {p.skillset}")
+    click.echo(f"Status:   {p.status}")
+    click.echo(f"Created:  {p.created}")
+    if p.notes:
+        click.echo(f"Notes:    {p.notes}")
+
+
+def _format_project_progress(resp: Any) -> None:
+    if not resp.stages:
+        click.echo("No pipeline stages found.")
+        return
+    for s in resp.stages:
+        mark = "x" if s.completed else " "
+        click.echo(f"  [{mark}] {s.order}. {s.description} ({s.skill})")
+    if resp.current_stage:
+        click.echo(f"\nCurrent: {resp.current_stage}")
+    if resp.next_prerequisite:
+        click.echo(f"Next gate: {resp.next_prerequisite}")
+
+
+def _format_decision_record(resp: Any) -> None:
+    click.echo(
+        f"Recorded decision '{resp.title}' for "
+        f"'{resp.client}/{resp.project_slug}' ({resp.decision_id})"
+    )
+
+
+def _format_decision_list(resp: Any) -> None:
+    if not resp.decisions:
+        click.echo("No decisions recorded.")
+        return
+    for d in resp.decisions:
+        click.echo(f"  {d.date}  {d.title}")
+        for k, v in d.fields.items():
+            click.echo(f"           {k}: {v}")
+
+
+def _format_engagement_add(resp: Any) -> None:
+    click.echo(
+        f"Added engagement entry '{resp.title}' for '{resp.client}' ({resp.entry_id})"
+    )
+
+
+def _format_research_add(resp: Any) -> None:
+    click.echo(
+        f"Registered topic '{resp.topic}' as '{resp.filename}' for '{resp.client}'"
+    )
+
+
+def _format_research_list(resp: Any) -> None:
+    if not resp.topics:
+        click.echo("No research topics found.")
+        return
+    for t in resp.topics:
+        click.echo(f"  {t.filename}  {t.topic}  {t.confidence}  {t.date}")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register consulting commands on the given CLI group."""
+
+    # -- project -----------------------------------------------------------
+
+    @cli.group()
+    def project() -> None:
+        """Manage consulting projects."""
+
+    project.add_command(
+        generate_command(
+            name="init",
+            request_model=InitializeWorkspaceRequest,
+            usecase_attr="initialize_workspace_usecase",
+            format_output=_format_init_workspace,
+        )
+    )
+    project.add_command(
+        generate_command(
+            name="register",
+            request_model=RegisterProjectRequest,
+            usecase_attr="register_project_usecase",
+            format_output=_format_register_project,
+        )
+    )
+    project.add_command(
+        generate_command(
+            name="update-status",
+            request_model=UpdateProjectStatusRequest,
+            usecase_attr="update_project_status_usecase",
+            format_output=_format_update_status,
+        )
+    )
+    project.add_command(
+        generate_command(
+            name="list",
+            request_model=ListProjectsRequest,
+            usecase_attr="list_projects_usecase",
+            format_output=_format_list_projects,
+        )
+    )
+    project.add_command(
+        generate_command(
+            name="get",
+            request_model=GetProjectRequest,
+            usecase_attr="get_project_usecase",
+            format_output=_format_get_project,
+        )
+    )
+    project.add_command(
+        generate_command(
+            name="progress",
+            request_model=GetProjectProgressRequest,
+            usecase_attr="get_project_progress_usecase",
+            format_output=_format_project_progress,
+        )
+    )
+
+    # -- decision ----------------------------------------------------------
+
+    @cli.group()
+    def decision() -> None:
+        """Manage project decisions."""
+
+    decision.add_command(
+        generate_command(
+            name="record",
+            request_model=RecordDecisionRequest,
+            usecase_attr="record_decision_usecase",
+            format_output=_format_decision_record,
+        )
+    )
+    decision.add_command(
+        generate_command(
+            name="list",
+            request_model=ListDecisionsRequest,
+            usecase_attr="list_decisions_usecase",
+            format_output=_format_decision_list,
+        )
+    )
+
+    # -- engagement --------------------------------------------------------
+
+    @cli.group()
+    def engagement() -> None:
+        """Manage client engagement history."""
+
+    engagement.add_command(
+        generate_command(
+            name="add",
+            request_model=AddEngagementEntryRequest,
+            usecase_attr="add_engagement_entry_usecase",
+            format_output=_format_engagement_add,
+        )
+    )
+
+    # -- research ----------------------------------------------------------
+
+    @cli.group()
+    def research() -> None:
+        """Manage research topics."""
+
+    research.add_command(
+        generate_command(
+            name="add",
+            request_model=RegisterResearchTopicRequest,
+            usecase_attr="register_research_topic_usecase",
+            format_output=_format_research_add,
+        )
+    )
+    research.add_command(
+        generate_command(
+            name="list",
+            request_model=ListResearchTopicsRequest,
+            usecase_attr="list_research_topics_usecase",
+            format_output=_format_research_list,
+        )
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ build-backend = "hatchling.build"
 packages = ["bin", "business_model_canvas", "consulting", "src/practice", "wardley_mapping"]
 
 [project.scripts]
-consultamatron = "bin.cli.main:cli"
+practice = "bin.cli.main:cli"

--- a/wardley_mapping/cli.py
+++ b/wardley_mapping/cli.py
@@ -1,0 +1,47 @@
+"""CLI command registration for the Wardley Mapping bounded context.
+
+Registers the tour command group.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from bin.cli.introspect import generate_command
+from wardley_mapping.dtos import RegisterTourRequest
+
+
+# ---------------------------------------------------------------------------
+# Format callbacks
+# ---------------------------------------------------------------------------
+
+
+def _format_tour_register(resp: Any) -> None:
+    click.echo(
+        f"Registered tour '{resp.name}' with {resp.stop_count} stops "
+        f"for '{resp.client}/{resp.project_slug}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register Wardley Mapping commands on the given CLI group."""
+
+    @cli.group()
+    def tour() -> None:
+        """Manage presentation tours."""
+
+    tour.add_command(
+        generate_command(
+            name="register",
+            request_model=RegisterTourRequest,
+            usecase_attr="register_tour_usecase",
+            format_output=_format_tour_register,
+        )
+    )


### PR DESCRIPTION
## Summary

- Each bounded context (`consulting/`, `wardley_mapping/`) now exports a `register_commands(cli)` function that wires its command groups onto the Click CLI
- `bin/cli/main.py` becomes a thin composition root: create CLI group, call BC registrations, keep `site` (cross-BC)
- Entry point renamed from `consultamatron` to `practice` in pyproject.toml and render-site.sh

Final PR in the bounded context packaging series (#47). Builds on #56, #57, #60, #63.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest -m doctrine` passes (66 passed)
- [x] `pytest` passes (303 passed)
- [x] `uv run practice --help` shows dynamically discovered commands
- [x] `uv run practice project list --client test` works