### PR TITLE
Add skillset list and skillset show CLI commands

### DIFF
--- a/bin/cli/di.py
+++ b/bin/cli/di.py
@@ -23,7 +23,11 @@ from bin.cli.infrastructure.json_repos import (
     JsonResearchTopicRepository,
     JsonTourManifestRepository,
 )
-from bin.cli.usecases import RenderSiteUseCase
+from bin.cli.usecases import (
+    ListSkillsetsUseCase,
+    RenderSiteUseCase,
+    ShowSkillsetUseCase,
+)
 from wardley_mapping.presenter import WardleyProjectPresenter
 from wardley_mapping.types import TourManifestRepository
 from wardley_mapping.usecases import RegisterTourUseCase
@@ -190,6 +194,12 @@ class Container:
         )
         self.list_research_topics_usecase = ListResearchTopicsUseCase(
             research=self.research,
+        )
+        self.list_skillsets_usecase = ListSkillsetsUseCase(
+            skillsets=self.skillsets,
+        )
+        self.show_skillset_usecase = ShowSkillsetUseCase(
+            skillsets=self.skillsets,
         )
         self.render_site_usecase = RenderSiteUseCase(
             projects=self.projects,

--- a/bin/cli/dtos.py
+++ b/bin/cli/dtos.py
@@ -61,8 +61,14 @@ __all__ = [
     "RegisterResearchTopicResponse",
     "RegisterTourRequest",
     "RegisterTourResponse",
+    "ListSkillsetsRequest",
+    "ListSkillsetsResponse",
     "RenderSiteRequest",
     "RenderSiteResponse",
+    "ShowSkillsetRequest",
+    "ShowSkillsetResponse",
+    "SkillsetInfo",
+    "SkillsetStageInfo",
     "ResearchTopicInfo",
     "StageProgress",
     "UpdateProjectStatusRequest",
@@ -85,3 +91,42 @@ class RenderSiteResponse(BaseModel):
     client: str
     site_path: str
     page_count: int
+
+
+# ---------------------------------------------------------------------------
+# Skillset — stays here (cross-BC, aggregates from all BCs)
+# ---------------------------------------------------------------------------
+
+
+class SkillsetStageInfo(BaseModel):
+    order: int
+    skill: str
+    description: str
+    prerequisite_gate: str
+    produces_gate: str
+
+
+class SkillsetInfo(BaseModel):
+    name: str
+    display_name: str
+    description: str
+    slug_pattern: str
+    stages: list[SkillsetStageInfo]
+
+
+class ListSkillsetsRequest(BaseModel):
+    """List all registered skillsets."""
+
+
+class ListSkillsetsResponse(BaseModel):
+    skillsets: list[SkillsetInfo]
+
+
+class ShowSkillsetRequest(BaseModel):
+    """Show details of a registered skillset."""
+
+    name: str = Field(description="Skillset name.")
+
+
+class ShowSkillsetResponse(BaseModel):
+    skillset: SkillsetInfo

--- a/bin/cli/main.py
+++ b/bin/cli/main.py
@@ -15,7 +15,7 @@ import click
 
 from bin.cli.config import Config
 from bin.cli.di import Container
-from bin.cli.dtos import RenderSiteRequest
+from bin.cli.dtos import ListSkillsetsRequest, RenderSiteRequest, ShowSkillsetRequest
 from bin.cli.introspect import generate_command
 
 import consulting.cli
@@ -33,6 +33,53 @@ def cli(ctx: click.Context) -> None:
 
 consulting.cli.register_commands(cli)
 wardley_mapping.cli.register_commands(cli)
+
+
+# ---------------------------------------------------------------------------
+# skillset (cross-BC, stays here)
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def skillset() -> None:
+    """Browse registered skillsets."""
+
+
+def _format_skillset_list(resp: Any) -> None:
+    if not resp.skillsets:
+        click.echo("No skillsets registered.")
+        return
+    for s in resp.skillsets:
+        click.echo(f"  {s.name}  {s.display_name}  ({len(s.stages)} stages)")
+
+
+def _format_skillset_show(resp: Any) -> None:
+    s = resp.skillset
+    click.echo(f"Name:        {s.name}")
+    click.echo(f"Display:     {s.display_name}")
+    click.echo(f"Description: {s.description}")
+    click.echo(f"Slug:        {s.slug_pattern}")
+    click.echo(f"Pipeline:    {len(s.stages)} stages")
+    for st in s.stages:
+        click.echo(f"  {st.order}. {st.description} ({st.skill})")
+
+
+skillset.add_command(
+    generate_command(
+        name="list",
+        request_model=ListSkillsetsRequest,
+        usecase_attr="list_skillsets_usecase",
+        format_output=_format_skillset_list,
+    )
+)
+skillset.add_command(
+    generate_command(
+        name="show",
+        request_model=ShowSkillsetRequest,
+        usecase_attr="show_skillset_usecase",
+        format_output=_format_skillset_show,
+    )
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `practice skillset list` and `practice skillset show --name <name>` commands
- Cross-BC commands in `bin/cli/main.py` (alongside `site`), backed by `ListSkillsetsUseCase` and `ShowSkillsetUseCase` in `bin/cli/usecases.py`
- Follows the existing DTO/usecase/`generate_command` pattern

```
$ practice skillset list
  wardley-mapping  Wardley Mapping  (5 stages)
  business-model-canvas  Business Model Canvas  (3 stages)

$ practice skillset show --name wardley-mapping
Name:        wardley-mapping
Display:     Wardley Mapping
Description: Strategic mapping methodology...
Slug:        maps-{n}
Pipeline:    5 stages
  1. Stage 1: Project brief agreed (wm-research)
  ...
```

Closes #65

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest -m doctrine` passes (66 passed)
- [x] `pytest` passes (303 passed)
- [x] `practice skillset list` shows both skillsets
- [x] `practice skillset show --name wardley-mapping` shows full details
- [x] `practice skillset show --name nonexistent` returns error