### PR TITLE
Add contributor assignment agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,193 @@
+# Consultamatron Individual Contributor Assignment Agreement
+
+Based on the Harmony Individual Contributor Assignment Agreement
+(HA-CAA-I v1.0), adapted for the Consultamatron project.
+
+## Agreement
+
+Thank you for your interest in contributing to **Consultamatron**
+(the "Project"), maintained by **Chris Gough** (the "Maintainer").
+
+This Contributor Assignment Agreement ("Agreement") documents the
+rights granted by contributors to the Maintainer. To make this
+document effective, please follow the signing process described in
+CONTRIBUTING.md.
+
+This is a legally binding document, so please read it carefully
+before agreeing to it.
+
+### 1. Definitions
+
+**"You"** means the individual who Submits a Contribution to the
+Project.
+
+**"Contribution"** means any work of authorship that is Submitted by
+You to the Project, in which You own or assert ownership of the
+Copyright.
+
+**"Copyright"** means all rights protecting works of authorship owned
+or controlled by You, including copyright, moral and neighbouring
+rights, as appropriate, for the full term of their existence
+including any extensions by You.
+
+**"Material"** means the work of authorship which is made available
+by the Project, to which Your Contribution was Submitted.
+
+**"Submit"** means any form of electronic, verbal, or written
+communication sent to the Project or its representatives, including
+but not limited to electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf
+of, the Project for the purpose of discussing and improving the
+Material, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as "Not a Contribution."
+
+**"Submission Date"** means the date on which You Submit a
+Contribution to the Project.
+
+**"Effective Date"** means the date You execute this Agreement or the
+date You first Submit a Contribution to the Project, whichever is
+earlier.
+
+### 2. Copyright Assignment
+
+**(a)** At the time the Contribution is Submitted, You assign to the
+Maintainer all right, title, and interest worldwide in all Copyright
+covering the Contribution.
+
+**(b)** To the extent that any of the rights in Section 2(a) cannot
+be assigned by You to the Maintainer, You grant to the Maintainer a
+perpetual, worldwide, exclusive, royalty-free, transferable,
+irrevocable licence under such non-assigned rights, with rights to
+sublicence through multiple tiers of sublicensees, to practise such
+non-assigned rights, including, but not limited to, the right to
+reproduce, modify, display, perform, and distribute the Contribution.
+
+**(c)** To the extent that any of the rights in Section 2(a) can
+neither be assigned nor licensed by You to the Maintainer, You
+irrevocably waive and agree never to assert such rights against the
+Maintainer, any of the Maintainer's successors in interest, or any of
+the Maintainer's licensees, either direct or indirect.
+
+**(d)** Upon such assignment of rights to the Maintainer, to the
+maximum extent possible, the Maintainer immediately grants to You a
+perpetual, worldwide, non-exclusive, royalty-free, transferable,
+irrevocable licence under such rights covering the Contribution, with
+rights to sublicence through multiple tiers of sublicensees, to
+reproduce, modify, display, perform, and distribute the Contribution.
+The intention of this section is that You retain the ability to use
+Your own Contribution for any purpose.
+
+**(e)** The Maintainer is not restricted in how the Contribution may
+be licensed. As the copyright assignee, the Maintainer may license
+the Contribution under any terms, including but not limited to the
+Project's current licence (GNU General Public License, version 3 or
+later), other open source licences, proprietary licences, or dual
+licensing arrangements. Contributors should understand that by
+assigning copyright, they grant the Maintainer unrestricted
+discretion over licensing.
+
+### 3. Patent Licence
+
+For patent claims including, without limitation, method, process, and
+apparatus claims which You own, control, or have the right to grant,
+now or in the future, You grant to the Maintainer a perpetual,
+worldwide, non-exclusive, transferable, royalty-free, irrevocable
+patent licence, with the right to sublicence these rights to multiple
+tiers of sublicensees, to make, have made, use, sell, offer for sale,
+import, and otherwise transfer the Contribution and the Contribution
+in combination with the Material (and portions of such combination).
+This licence is granted only to the extent that the exercise of the
+licensed rights infringes such patent claims; and if the Maintainer
+assigns these patent rights to a third party, the third party shall
+also be bound by this licence.
+
+### 4. Representations
+
+You represent that You are legally entitled to grant the above
+assignment and licences. If Your employer(s) has rights to
+intellectual property that You create that includes Your
+Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has
+waived such rights for Your Contributions to the Project, or that
+Your employer has executed a separate agreement with the Maintainer.
+
+You represent that each of Your Contributions is Your original
+creation (see Section 6 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete details
+of any third-party licence or other restriction (including, but not
+limited to, related patents and trademarks) of which You are
+personally aware and which are associated with any part of Your
+Contributions.
+
+### 5. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 4, THE CONTRIBUTION IS
+PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES
+INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO THE MAINTAINER
+AND BY THE MAINTAINER TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES
+CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION TO THE
+MINIMUM PERIOD PERMITTED BY LAW.
+
+### 6. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL
+YOU OR THE MAINTAINER BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF
+ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL,
+CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF THIS AGREEMENT OR
+RESULTING FROM YOUR CONTRIBUTION, REGARDLESS OF WHETHER ANY ACTION IS
+BASED ON CONTRACT, TORT INCLUDING NEGLIGENCE, STRICT LIABILITY, OR
+ANY OTHER LEGAL OR EQUITABLE THEORY, EVEN IF THE PARTY HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 7. Third-Party Contributions
+
+Should You wish to Submit work that is not Your original creation,
+You may Submit it to the Project separately from any Contribution,
+identifying the complete details of its source and of any licence or
+other restriction (including, but not limited to, related patents,
+trademarks, and licence agreements) of which You are personally
+aware, and conspicuously marking the work as "Submitted on behalf of
+a third party: [named here]".
+
+### 8. Miscellaneous
+
+This Agreement shall be governed by the laws of **Australia**,
+excluding its conflict-of-law provisions. Under certain circumstances,
+the governing law in this section might be superseded by the United
+Nations Convention on Contracts for the International Sale of Goods
+("UN Convention") and the parties agree that the UN Convention shall
+not apply to this Agreement. The parties agree to attempt to resolve
+any disputes in good faith before pursuing formal legal proceedings.
+
+This Agreement sets out the entire agreement between You and the
+Maintainer for Your Contributions to the Project and overrides all
+other agreements or understandings.
+
+If You or the Maintainer assigns the rights or obligations received
+through this Agreement to a third party, as a condition of the
+assignment, that third party must agree in writing to abide by all
+the rights and obligations in the Agreement.
+
+The failure of either party to require performance by the other party
+of any provision of this Agreement in one situation shall not affect
+the right of a party to require such performance at any time in the
+future. A waiver of performance under a provision in one situation
+shall not be considered a waiver of the provision itself.
+
+If any provision of this Agreement is found void and unenforceable,
+such provision will be replaced to the extent possible with a
+provision that comes closest to the meaning of the original provision
+and which is enforceable. The terms and conditions set forth in this
+Agreement shall apply notwithstanding any failure of essential purpose
+of this Agreement or any limited remedy to the maximum extent
+possible under law.
+
+---
+
+*This agreement is adapted from the Harmony Individual Contributor
+Assignment Agreement (HA-CAA-I), version 1.0, published July 4, 2011
+by Project Harmony. The original is licensed under Creative Commons
+Attribution 3.0 Unported. See https://www.harmonyagreements.org/ for
+the original templates.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Consultamatron
+
+## Contributor Assignment Agreement
+
+All contributions to this project require a signed Contributor
+Assignment Agreement (CLA). The agreement is in [CLA.md](CLA.md).
+
+By signing the CLA, you:
+
+1. **Assign copyright** in your contribution to the project maintainer
+2. **Attest** that you have the right to make that assignment
+3. **Receive back** a perpetual, irrevocable licence to your own
+   contribution, so you can continue to use your own code however you
+   wish
+
+The project is currently licensed under the GPL (version 3 or later).
+The CLA does not restrict the maintainer's licensing choices — as the
+copyright owner, the maintainer retains full discretion over how the
+codebase is licensed.
+
+## How to sign
+
+When you open your first pull request, the CLA Assistant bot will
+prompt you to sign the agreement. You sign by posting a comment in
+the pull request with the exact text:
+
+> I have read the CLA document and I hereby sign the Contributor
+> Assignment Agreement.
+
+This is recorded against your GitHub username. You only need to sign
+once — all future contributions are covered.
+
+### If your employer may own your work
+
+If you are employed and your employer may have rights to intellectual
+property you create (common for software developers), you should
+either:
+
+- Get written permission from your employer to contribute, or
+- Have your employer waive their rights for contributions to this
+  project, or
+- Have your employer contact the maintainer to execute a separate
+  corporate agreement
+
+The CLA requires you to represent that you have handled this. Do not
+sign if you are unsure — check with your employer first.
+
+## What this means in practice
+
+**For contributors**: You are giving away ownership of the code you
+contribute. In return, you get a licence back to use your own code
+for any purpose. The project will always be GPL. Your name remains in
+the git history as the author of your contribution.
+
+**For the project**: Consolidated copyright ownership means the
+maintainer can enforce the GPL as a single entity, without needing to
+coordinate with every contributor. This is the same model the FSF
+used for GNU projects for decades.
+
+**What the maintainer can do**: As copyright owner, the maintainer
+has unrestricted licensing discretion. The project is currently GPL
+but this is a choice, not a constraint. Section 2(d) guarantees your
+licence-back regardless of what the maintainer does with the
+codebase.
+
+## Code contributions
+
+### Branch workflow
+
+- Fork the repository
+- Create a feature branch from `master`
+- Make your changes
+- Open a pull request against `master`
+
+### Commit style
+
+Linux kernel style:
+
+- Imperative mood: "Add feature" not "Added feature"
+- First line is a directive summary (50 chars or less ideal)
+- Blank line, then explanatory body if needed
+- No conventional commit prefixes (`feat:`, `fix:`, etc.)
+
+### Before submitting
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest -m doctrine
+```
+
+All three must pass.
+
+## Skill contributions
+
+Skills are agent-native documents (`{skill-name}/SKILL.md`). If you
+are contributing a new skill or modifying an existing one:
+
+- Read existing skills to understand the structure and voice
+- Follow the YAML frontmatter convention
+- Respect the gate protocol — never create `.agreed.md` artifacts
+  without describing the client agreement loop
+- Test the skill by running it with an agent against a real or
+  synthetic client workspace
+
+## Questions
+
+Open an issue if you have questions about the CLA or contribution
+process.


### PR DESCRIPTION
## Summary

- Adds CLA.md: Copyright Assignment Agreement based on Harmony HA-CAA-I v1.0
- Adds CONTRIBUTING.md: explains signing process, branch workflow, commit style, and skill contribution guidelines

The CLA assigns copyright to the maintainer with unrestricted licensing discretion and an irrevocable licence-back to contributors. Section 2(e) is explicit that the maintainer retains full discretion — no outbound license restriction.

Remaining setup: install [CLA Assistant](https://cla-assistant.io/) GitHub App and point it at CLA.md.

Closes #62