### PR TITLE
Add CLA Assistant GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,39 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: |
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "https://github.com/monkeypants/consultamatron/blob/master/CLA.md"
+          path-to-signatures: "signatures/cla.json"
+          branch: "master"
+          allowlist: monkeypants,dependabot*,github-actions*
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this, you
+            need to sign the [Contributor Assignment Agreement](https://github.com/monkeypants/consultamatron/blob/master/CLA.md).
+
+            To sign, please post the following comment in this pull request:
+
+            > I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: |
+            All contributors have signed the CLA. Thank you!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,15 +20,14 @@ codebase is licensed.
 
 ## How to sign
 
-When you open your first pull request, the CLA Assistant bot will
-prompt you to sign the agreement. You sign by posting a comment in
-the pull request with the exact text:
+When you open your first pull request, the CLA Assistant will
+comment asking you to sign. You sign by posting a comment in the
+pull request with the exact text:
 
-> I have read the CLA document and I hereby sign the Contributor
-> Assignment Agreement.
+> I have read the CLA Document and I hereby sign the CLA
 
-This is recorded against your GitHub username. You only need to sign
-once — all future contributions are covered.
+Your signature is recorded against your GitHub username. You only
+need to sign once — all future contributions are covered.
 
 ### If your employer may own your work
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cla.yml` using [contributor-assistant/github-action](https://github.com/contributor-assistant/github-action) v2.6.1
- Updates CONTRIBUTING.md signing text to match the action's trigger string

Signatures stored in `signatures/cla.json` on master. Uses built-in `GITHUB_TOKEN` only — no secrets to configure. `monkeypants`, `dependabot*`, and `github-actions*` are allowlisted.

Follow-up to #70. Completes #62.