### PR TITLE
Allowlist maintainer email in CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-document: "https://github.com/monkeypants/consultamatron/blob/master/CLA.md"
           path-to-signatures: "signatures/cla.json"
           branch: "master"
-          allowlist: monkeypants,dependabot*,github-actions*
+          allowlist: monkeypants,chris.gough@gosource.com.au,dependabot*,github-actions*
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this, you
             need to sign the [Contributor Assignment Agreement](https://github.com/monkeypants/consultamatron/blob/master/CLA.md).


### PR DESCRIPTION
## Summary

The CLA assistant checks commit authors (git email), not PR authors (GitHub login). Commits from `chris.gough@gosource.com.au` don't map to the `monkeypants` GitHub account, so the username allowlist alone doesn't bypass the CLA check for the maintainer.

Adds the email to the allowlist alongside the username.

## Context

Discovered on PR #73 where the CLA check failed despite the PR author being the repo owner.