### PR TITLE
Skip CLA check for repo owner PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,12 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    # Skip CLA for repo owner — the action matches by GitHub login on
+    # commits, which fails when the committer's git email is not linked
+    # to their GitHub account (and linking it opts into GitHub spam).
+    if: >-
+      github.event.pull_request.author_association != 'OWNER'
+      || github.event_name == 'issue_comment'
     steps:
       - name: "CLA Assistant"
         if: |
@@ -27,7 +33,7 @@ jobs:
           path-to-document: "https://github.com/monkeypants/consultamatron/blob/master/CLA.md"
           path-to-signatures: "signatures/cla.json"
           branch: "master"
-          allowlist: monkeypants,chris.gough@gosource.com.au,dependabot*,github-actions*
+          allowlist: monkeypants,dependabot*,github-actions*
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this, you
             need to sign the [Contributor Assignment Agreement](https://github.com/monkeypants/consultamatron/blob/master/CLA.md).


### PR DESCRIPTION
## Summary

The CLA assistant matches commit authors by GitHub login, but commits from `chris.gough@gosource.com.au` have an empty login because that email isn't linked to the GitHub account. Linking it would opt into GitHub's email spam, which is not acceptable.

The `allowlist` parameter only supports GitHub usernames, not email addresses (despite what one might hope). The email added in #74 had no effect.

Fix: skip the entire CLA job when `github.event.pull_request.author_association == 'OWNER'`. This is set by GitHub based on the PR author (which resolves correctly), not the commit author. The `issue_comment` event path is preserved so external contributors can still sign via comment.

## Behaviour matrix

| Event | Author | Job runs? |
|-------|--------|-----------|
| PR opened | Owner | No (skipped) |
| PR opened | Contributor | Yes |
| Comment "recheck" | Anyone | Yes |
| Comment "I sign" | Anyone | Yes |