### PR TITLE
Enrich Skillset entity with descriptive fields

### DIFF
--- a/bin/cli/di.py
+++ b/bin/cli/di.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime, timezone
 
-import business_model_canvas
-import wardley_mapping as wardley_mapping_mod
 from bin.cli.config import Config
 from bin.cli.infrastructure.code_skillset_repository import CodeSkillsetRepository
 from bin.cli.infrastructure.composite_skillset_repository import (
@@ -20,6 +18,7 @@ from bin.cli.infrastructure.composite_skillset_repository import (
 from bin.cli.infrastructure.filesystem_source_repository import (
     FilesystemSourceRepository,
 )
+from bin.cli.infrastructure.skillset_scaffold import SkillsetScaffold
 from business_model_canvas.presenter import BmcProjectPresenter
 from bin.cli.infrastructure.jinja_renderer import JinjaSiteRenderer
 from bin.cli.infrastructure.json_repos import (
@@ -33,9 +32,11 @@ from bin.cli.infrastructure.json_repos import (
 from bin.cli.usecases import (
     ListSkillsetsUseCase,
     ListSourcesUseCase,
+    RegisterProspectusUseCase,
     RenderSiteUseCase,
     ShowSkillsetUseCase,
     ShowSourceUseCase,
+    UpdateProspectusUseCase,
 )
 from wardley_mapping.presenter import WardleyProjectPresenter
 from wardley_mapping.types import TourManifestRepository
@@ -123,7 +124,7 @@ class Container:
 
         # -- Repositories --------------------------------------------------
         _commons_skillsets = CodeSkillsetRepository(
-            [wardley_mapping_mod, business_model_canvas],
+            config.repo_root,
         )
         self.skillsets: SkillsetRepository = CompositeSkillsetRepository(
             _commons_skillsets, config.repo_root
@@ -274,4 +275,15 @@ class Container:
             research=self.research,
             renderer=self.site_renderer,
             presenters=self.presenters,
+        )
+
+        # -- Prospectus usecases -------------------------------------------
+        self.scaffold = SkillsetScaffold(config.repo_root)
+        self.register_prospectus_usecase = RegisterProspectusUseCase(
+            skillsets=self.skillsets,
+            scaffold=self.scaffold,
+        )
+        self.update_prospectus_usecase = UpdateProspectusUseCase(
+            skillsets=self.skillsets,
+            scaffold=self.scaffold,
         )

--- a/bin/cli/dtos.py
+++ b/bin/cli/dtos.py
@@ -57,6 +57,8 @@ __all__ = [
     "RecordDecisionResponse",
     "RegisterProjectRequest",
     "RegisterProjectResponse",
+    "RegisterProspectusRequest",
+    "RegisterProspectusResponse",
     "RegisterResearchTopicRequest",
     "RegisterResearchTopicResponse",
     "RegisterTourRequest",
@@ -78,6 +80,8 @@ __all__ = [
     "ListSourcesResponse",
     "ShowSourceRequest",
     "ShowSourceResponse",
+    "UpdateProspectusRequest",
+    "UpdateProspectusResponse",
 ]
 
 
@@ -116,6 +120,12 @@ class SkillsetInfo(BaseModel):
     display_name: str
     description: str
     slug_pattern: str
+    is_implemented: bool
+    problem_domain: str
+    deliverables: list[str]
+    value_proposition: str
+    classification: list[str]
+    evidence: list[str]
     stages: list[SkillsetStageInfo]
 
 
@@ -124,6 +134,11 @@ class ListSkillsetsRequest(BaseModel):
 
     client: str | None = Field(default=None, description="Client slug.")
     engagement: str | None = Field(default=None, description="Engagement slug.")
+
+    implemented: str | None = Field(
+        default=None,
+        description="Filter by implementation status: 'true', 'false', or omit for all.",
+    )
 
 
 class ListSkillsetsResponse(BaseModel):
@@ -167,3 +182,66 @@ class ShowSourceRequest(BaseModel):
 
 class ShowSourceResponse(BaseModel):
     source: SourceInfo
+
+
+# ---------------------------------------------------------------------------
+# Prospectus — register and update unimplemented skillsets
+# ---------------------------------------------------------------------------
+
+
+class RegisterProspectusRequest(BaseModel):
+    """Register a new skillset prospectus."""
+
+    name: str = Field(description="Skillset name (kebab-case).")
+    display_name: str = Field(description="Human-readable display name.")
+    description: str = Field(description="Short description of the methodology.")
+    slug_pattern: str = Field(description="Project slug pattern with {n} placeholder.")
+    problem_domain: str = Field(default="", description="Problem domain.")
+    value_proposition: str = Field(default="", description="Value proposition.")
+    deliverables: str = Field(
+        default="",
+        description="Comma-separated list of deliverables.",
+    )
+    classification: str = Field(
+        default="",
+        description="Comma-separated classification tags.",
+    )
+    evidence: str = Field(
+        default="",
+        description="Comma-separated evidence references.",
+    )
+
+
+class RegisterProspectusResponse(BaseModel):
+    name: str
+    init_path: str
+
+
+class UpdateProspectusRequest(BaseModel):
+    """Update an existing skillset prospectus."""
+
+    name: str = Field(description="Skillset name to update.")
+    display_name: str | None = Field(default=None, description="New display name.")
+    description: str | None = Field(default=None, description="New description.")
+    slug_pattern: str | None = Field(default=None, description="New slug pattern.")
+    problem_domain: str | None = Field(default=None, description="New problem domain.")
+    value_proposition: str | None = Field(
+        default=None, description="New value proposition."
+    )
+    deliverables: str | None = Field(
+        default=None,
+        description="Comma-separated list of deliverables (replaces existing).",
+    )
+    classification: str | None = Field(
+        default=None,
+        description="Comma-separated classification tags (replaces existing).",
+    )
+    evidence: str | None = Field(
+        default=None,
+        description="Comma-separated evidence references (replaces existing).",
+    )
+
+
+class UpdateProspectusResponse(BaseModel):
+    name: str
+    init_path: str

--- a/bin/cli/infrastructure/code_skillset_repository.py
+++ b/bin/cli/infrastructure/code_skillset_repository.py
@@ -1,26 +1,62 @@
 """Skillset repository that aggregates SKILLSETS from BC modules.
 
-Replaces JsonSkillsetRepository by reading skillset declarations
-directly from bounded context packages instead of from a JSON file.
+Discovers bounded context packages dynamically by reading the packages
+list from pyproject.toml, importing each, and collecting those that
+export a SKILLSETS attribute.
 """
 
 from __future__ import annotations
 
-from types import ModuleType
+import importlib
+import tomllib
+from pathlib import Path
 
 from practice.entities import Skillset
+
+
+def _read_pyproject_packages(pyproject_path: Path) -> list[str]:
+    """Read the packages list from pyproject.toml.
+
+    Looks in [tool.hatch.build.targets.wheel].packages and converts
+    filesystem paths (e.g. "src/practice") to importable module names
+    (e.g. "practice").
+    """
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+
+    packages = (
+        data.get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("wheel", {})
+        .get("packages", [])
+    )
+
+    names = []
+    for pkg in packages:
+        # "src/practice" -> "practice", "wardley_mapping" -> "wardley_mapping"
+        name = Path(pkg).name
+        names.append(name)
+    return names
 
 
 class CodeSkillsetRepository:
     """Aggregates SKILLSETS attributes from bounded context modules.
 
-    Each module must export a SKILLSETS: list[Skillset] attribute.
+    Discovers packages from pyproject.toml, imports each, and collects
+    those with a SKILLSETS: list[Skillset] attribute.
     """
 
-    def __init__(self, modules: list[ModuleType]) -> None:
+    def __init__(self, repo_root: Path) -> None:
         self._skillsets: list[Skillset] = []
-        for module in modules:
-            self._skillsets.extend(module.SKILLSETS)
+        packages = _read_pyproject_packages(repo_root / "pyproject.toml")
+        for pkg_name in packages:
+            try:
+                mod = importlib.import_module(pkg_name)
+                self._skillsets.extend(getattr(mod, "SKILLSETS", []))
+            except ImportError:
+                continue
 
     def get(self, name: str) -> Skillset | None:
         for s in self._skillsets:

--- a/bin/cli/infrastructure/skillset_scaffold.py
+++ b/bin/cli/infrastructure/skillset_scaffold.py
@@ -1,0 +1,207 @@
+"""Scaffold infrastructure for creating and updating skillset stub packages.
+
+Creates bounded context packages with __init__.py files that export
+SKILLSETS declarations and registers them in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+class SkillsetScaffold:
+    """Creates and updates skillset stub packages.
+
+    A stub package is a Python package with __init__.py that exports
+    a SKILLSETS list. The scaffold also manages the pyproject.toml
+    packages list to ensure new packages are discoverable.
+    """
+
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root
+        self._src_root = repo_root / "src"
+
+    def _package_dir(self, name: str) -> Path:
+        """Return the filesystem path for a skillset package."""
+        return self._src_root / name.replace("-", "_")
+
+    def create(
+        self,
+        name: str,
+        display_name: str,
+        description: str,
+        slug_pattern: str,
+        problem_domain: str = "",
+        value_proposition: str = "",
+        deliverables: list[str] | None = None,
+        classification: list[str] | None = None,
+        evidence: list[str] | None = None,
+    ) -> Path:
+        """Create a stub BC package with a SKILLSETS declaration.
+
+        Returns the path to the created __init__.py.
+        """
+        pkg_dir = self._package_dir(name)
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        init_py = pkg_dir / "__init__.py"
+        init_py.write_text(
+            _render_init(
+                name=name,
+                display_name=display_name,
+                description=description,
+                slug_pattern=slug_pattern,
+                problem_domain=problem_domain,
+                value_proposition=value_proposition,
+                deliverables=deliverables or [],
+                classification=classification or [],
+                evidence=evidence or [],
+            )
+        )
+        self._add_to_pyproject(name)
+        return init_py
+
+    def update(
+        self,
+        name: str,
+        display_name: str | None = None,
+        description: str | None = None,
+        slug_pattern: str | None = None,
+        problem_domain: str | None = None,
+        value_proposition: str | None = None,
+        deliverables: list[str] | None = None,
+        classification: list[str] | None = None,
+        evidence: list[str] | None = None,
+    ) -> Path:
+        """Update an existing stub package's SKILLSETS declaration.
+
+        Reads the current __init__.py, applies changes, rewrites it.
+        Returns the path to the updated __init__.py.
+        """
+        pkg_dir = self._package_dir(name)
+        init_py = pkg_dir / "__init__.py"
+
+        current = _parse_current_skillset(init_py, name)
+
+        init_py.write_text(
+            _render_init(
+                name=name,
+                display_name=display_name
+                if display_name is not None
+                else current.display_name,
+                description=description
+                if description is not None
+                else current.description,
+                slug_pattern=slug_pattern
+                if slug_pattern is not None
+                else current.slug_pattern,
+                problem_domain=problem_domain
+                if problem_domain is not None
+                else current.problem_domain,
+                value_proposition=value_proposition
+                if value_proposition is not None
+                else current.value_proposition,
+                deliverables=deliverables
+                if deliverables is not None
+                else current.deliverables,
+                classification=classification
+                if classification is not None
+                else current.classification,
+                evidence=evidence if evidence is not None else current.evidence,
+            )
+        )
+        return init_py
+
+    def _add_to_pyproject(self, name: str) -> None:
+        """Add the package to pyproject.toml's packages list."""
+        pyproject_path = self._repo_root / "pyproject.toml"
+        content = pyproject_path.read_text()
+
+        # The relative path from repo root into src/
+        pkg_path = f"src/{name.replace('-', '_')}"
+
+        # Match the packages = [...] line and append if not present
+        pattern = r"(packages\s*=\s*\[)([^\]]*?)(\])"
+        match = re.search(pattern, content)
+        if match is None:
+            return
+
+        existing = match.group(2)
+        if pkg_path in existing:
+            return
+
+        # Add the new package before the closing bracket
+        if existing.rstrip().endswith('"'):
+            new_packages = existing.rstrip() + f', "{pkg_path}"'
+        else:
+            new_packages = existing + f'"{pkg_path}"'
+
+        content = (
+            content[: match.start()]
+            + match.group(1)
+            + new_packages
+            + match.group(3)
+            + content[match.end() :]
+        )
+        pyproject_path.write_text(content)
+
+
+def _render_init(
+    name: str,
+    display_name: str,
+    description: str,
+    slug_pattern: str,
+    problem_domain: str,
+    value_proposition: str,
+    deliverables: list[str],
+    classification: list[str],
+    evidence: list[str],
+) -> str:
+    """Render the __init__.py content for a skillset stub package."""
+    parts = [
+        f'"""{display_name} bounded context."""\n',
+        "",
+        "from practice.entities import Skillset",
+        "",
+        "SKILLSETS: list[Skillset] = [",
+        "    Skillset(",
+        f"        name={name!r},",
+        f"        display_name={display_name!r},",
+        f"        description={description!r},",
+        f"        slug_pattern={slug_pattern!r},",
+    ]
+    if problem_domain:
+        parts.append(f"        problem_domain={problem_domain!r},")
+    if value_proposition:
+        parts.append(f"        value_proposition={value_proposition!r},")
+    if deliverables:
+        parts.append(f"        deliverables={deliverables!r},")
+    if classification:
+        parts.append(f"        classification={classification!r},")
+    if evidence:
+        parts.append(f"        evidence={evidence!r},")
+    parts.extend(
+        [
+            "    ),",
+            "]",
+            "",
+        ]
+    )
+    return "\n".join(parts)
+
+
+def _parse_current_skillset(init_py: Path, name: str):
+    """Parse the current Skillset from an __init__.py file.
+
+    Uses exec to evaluate the module in a controlled namespace.
+    """
+    from practice.entities import Skillset
+
+    namespace: dict = {"Skillset": Skillset}
+    exec(compile(init_py.read_text(), str(init_py), "exec"), namespace)
+    skillsets = namespace.get("SKILLSETS", [])
+    for s in skillsets:
+        if s.name == name:
+            return s
+    msg = f"Skillset {name!r} not found in {init_py}"
+    raise ValueError(msg)

--- a/bin/cli/main.py
+++ b/bin/cli/main.py
@@ -18,9 +18,11 @@ from bin.cli.di import Container
 from bin.cli.dtos import (
     ListSkillsetsRequest,
     ListSourcesRequest,
+    RegisterProspectusRequest,
     RenderSiteRequest,
     ShowSkillsetRequest,
     ShowSourceRequest,
+    UpdateProspectusRequest,
 )
 from bin.cli.introspect import generate_command
 
@@ -48,7 +50,7 @@ wardley_mapping.cli.register_commands(cli)
 
 @cli.group()
 def skillset() -> None:
-    """Browse registered skillsets."""
+    """Browse and manage registered skillsets."""
 
 
 def _format_skillset_list(resp: Any) -> None:
@@ -56,18 +58,40 @@ def _format_skillset_list(resp: Any) -> None:
         click.echo("No skillsets registered.")
         return
     for s in resp.skillsets:
-        click.echo(f"  {s.name}  {s.display_name}  ({len(s.stages)} stages)")
+        status = "implemented" if s.is_implemented else "prospectus"
+        click.echo(f"  {s.name}  {s.display_name}  ({len(s.stages)} stages, {status})")
 
 
 def _format_skillset_show(resp: Any) -> None:
     s = resp.skillset
+    status = "implemented" if s.is_implemented else "prospectus"
     click.echo(f"Name:        {s.name}")
     click.echo(f"Display:     {s.display_name}")
     click.echo(f"Description: {s.description}")
     click.echo(f"Slug:        {s.slug_pattern}")
+    click.echo(f"Status:      {status}")
+    if s.problem_domain:
+        click.echo(f"Domain:      {s.problem_domain}")
+    if s.value_proposition:
+        click.echo(f"Value:       {s.value_proposition}")
+    if s.deliverables:
+        click.echo(f"Deliverables: {', '.join(s.deliverables)}")
+    if s.classification:
+        click.echo(f"Tags:        {', '.join(s.classification)}")
+    if s.evidence:
+        click.echo(f"Evidence:    {', '.join(s.evidence)}")
     click.echo(f"Pipeline:    {len(s.stages)} stages")
     for st in s.stages:
         click.echo(f"  {st.order}. {st.description} ({st.skill})")
+
+
+def _format_prospectus_register(resp: Any) -> None:
+    click.echo(f"Registered prospectus: {resp.name}")
+    click.echo(f"Created: {resp.init_path}")
+
+
+def _format_prospectus_update(resp: Any) -> None:
+    click.echo(f"Updated prospectus: {resp.name}")
 
 
 skillset.add_command(
@@ -84,6 +108,22 @@ skillset.add_command(
         request_model=ShowSkillsetRequest,
         usecase_attr="show_skillset_usecase",
         format_output=_format_skillset_show,
+    )
+)
+skillset.add_command(
+    generate_command(
+        name="add",
+        request_model=RegisterProspectusRequest,
+        usecase_attr="register_prospectus_usecase",
+        format_output=_format_prospectus_register,
+    )
+)
+skillset.add_command(
+    generate_command(
+        name="update",
+        request_model=UpdateProspectusRequest,
+        usecase_attr="update_prospectus_usecase",
+        format_output=_format_prospectus_update,
     )
 )
 

--- a/src/practice/entities.py
+++ b/src/practice/entities.py
@@ -24,13 +24,29 @@ from practice.discovery import PipelineStage
 
 
 class Skillset(BaseModel):
-    """A consulting product line declared in bounded context modules."""
+    """A consulting product line declared in bounded context modules.
+
+    A Skillset with a populated pipeline is implemented — projects can
+    be created and driven through the pipeline. A Skillset with an empty
+    pipeline is a prospectus — it describes a methodology that is not yet
+    operational.
+    """
 
     name: str
     display_name: str
     description: str
-    pipeline: list[PipelineStage]
+    pipeline: list[PipelineStage] = []
     slug_pattern: str
+    problem_domain: str = ""
+    deliverables: list[str] = []
+    value_proposition: str = ""
+    classification: list[str] = []
+    evidence: list[str] = []
+
+    @property
+    def is_implemented(self) -> bool:
+        """True when the pipeline has at least one stage."""
+        return len(self.pipeline) > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 import uuid
 from datetime import date, datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -36,6 +38,9 @@ from bin.cli.infrastructure.json_repos import (
 )
 
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -43,7 +48,12 @@ from bin.cli.infrastructure.json_repos import (
 
 @pytest.fixture
 def tmp_config(tmp_path):
-    """Config pointing at a fresh temp directory."""
+    """Config pointing at a fresh temp directory.
+
+    Copies pyproject.toml so CodeSkillsetRepository can discover
+    bounded context packages via dynamic import.
+    """
+    shutil.copy(_REPO_ROOT / "pyproject.toml", tmp_path / "pyproject.toml")
     return Config(
         repo_root=tmp_path,
         workspace_root=tmp_path / "clients",
@@ -165,6 +175,27 @@ def make_skillset(**overrides) -> Skillset:
             ),
         ],
         slug_pattern="maps-{n}",
+        problem_domain="Strategy",
+        deliverables=["OWM map files"],
+        value_proposition="Visual strategic clarity.",
+        classification=["strategy"],
+        evidence=[],
+    )
+    return Skillset(**(defaults | overrides))
+
+
+def make_prospectus(**overrides) -> Skillset:
+    defaults = dict(
+        name="competitive-analysis",
+        display_name="Competitive Analysis",
+        description="Market positioning methodology.",
+        pipeline=[],
+        slug_pattern="comp-{n}",
+        problem_domain="Market positioning",
+        deliverables=["Competitor landscape report"],
+        value_proposition="Know your rivals.",
+        classification=["strategy", "market-analysis"],
+        evidence=["Porter's Five Forces"],
     )
     return Skillset(**(defaults | overrides))
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -4,11 +4,12 @@ These tests verify that skillsets compose correctly with the engagement
 lifecycle layer (the semantic waist). They run under the ``doctrine``
 marker, which is the pre-push gate defined in CLAUDE.md.
 
-Four conformance properties:
-  1. Pipeline coherence — structural validation of skillset pipelines
+Five conformance properties:
+  1. Pipeline coherence — structural validation of implemented skillset pipelines
   2. Decision-title join — the fragile string join that drives progress
   3. Entity round-trip — JSON serialisation fidelity for all entities
   4. Presenter contract — each presenter produces valid ProjectContribution
+  5. Skillset discipline — field-level validation for all skillsets
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ import business_model_canvas
 import wardley_mapping
 from bin.cli.config import Config
 from bin.cli.di import Container
+from bin.cli.infrastructure.code_skillset_repository import _read_pyproject_packages
 from business_model_canvas.presenter import BmcProjectPresenter
 from bin.cli.infrastructure.json_repos import JsonTourManifestRepository
 from consulting.dtos import (
@@ -40,6 +42,7 @@ from .conftest import (
     make_decision,
     make_engagement,
     make_project,
+    make_prospectus,
     make_research,
     make_skillset,
     make_tour,
@@ -53,10 +56,16 @@ from .conftest import (
 _ALL_SKILLSETS: list[Skillset] = (
     wardley_mapping.SKILLSETS + business_model_canvas.SKILLSETS
 )
-SKILLSETS = [s.model_dump(mode="json") for s in _ALL_SKILLSETS]
-SKILLSET_IDS = [s["name"] for s in SKILLSETS]
+_IMPLEMENTED = [s for s in _ALL_SKILLSETS if s.is_implemented]
+_IMPLEMENTED_DICTS = [s.model_dump(mode="json") for s in _IMPLEMENTED]
+_IMPLEMENTED_IDS = [s["name"] for s in _IMPLEMENTED_DICTS]
+
+_ALL_DICTS = [s.model_dump(mode="json") for s in _ALL_SKILLSETS]
+_ALL_IDS = [s["name"] for s in _ALL_DICTS]
 
 CLIENT = "conformance-corp"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _write(path: Path, content: str) -> None:
@@ -64,20 +73,27 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content)
 
 
+def _write_pyproject(tmp_path: Path) -> None:
+    """Copy the real pyproject.toml into a tmp directory for Container."""
+    import shutil
+
+    shutil.copy(_REPO_ROOT / "pyproject.toml", tmp_path / "pyproject.toml")
+
+
 # ---------------------------------------------------------------------------
-# 1. Pipeline coherence
+# 1. Pipeline coherence (implemented skillsets only)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.doctrine
 class TestPipelineCoherence:
-    """Structural validation of skillset pipeline definitions."""
+    """Structural validation of implemented skillset pipeline definitions."""
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _IMPLEMENTED_DICTS, ids=_IMPLEMENTED_IDS)
     def test_non_empty(self, skillset):
         assert len(skillset["pipeline"]) >= 1
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _IMPLEMENTED_DICTS, ids=_IMPLEMENTED_IDS)
     def test_monotonic_order(self, skillset):
         orders = [s["order"] for s in skillset["pipeline"]]
         for i in range(1, len(orders)):
@@ -85,7 +101,7 @@ class TestPipelineCoherence:
                 f"Stage order not strictly ascending: {orders}"
             )
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _IMPLEMENTED_DICTS, ids=_IMPLEMENTED_IDS)
     def test_gate_chaining(self, skillset):
         stages = skillset["pipeline"]
         for i in range(1, len(stages)):
@@ -96,14 +112,14 @@ class TestPipelineCoherence:
                 f"({stages[i - 1]['produces_gate']})"
             )
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _IMPLEMENTED_DICTS, ids=_IMPLEMENTED_IDS)
     def test_unique_descriptions(self, skillset):
         descriptions = [s["description"] for s in skillset["pipeline"]]
         assert len(descriptions) == len(set(descriptions)), (
             f"Duplicate descriptions in {skillset['name']}: {descriptions}"
         )
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
     def test_slug_pattern_valid(self, skillset):
         assert "{n}" in skillset["slug_pattern"], (
             f"slug_pattern missing {{n}} placeholder: {skillset['slug_pattern']}"
@@ -111,7 +127,7 @@ class TestPipelineCoherence:
 
 
 # ---------------------------------------------------------------------------
-# 2. Decision-title join
+# 2. Decision-title join (implemented skillsets only)
 # ---------------------------------------------------------------------------
 
 
@@ -121,10 +137,11 @@ class TestDecisionTitleJoin:
     PipelineStage.description that drives GetProjectProgressUseCase.
     """
 
-    @pytest.mark.parametrize("skillset", SKILLSETS, ids=SKILLSET_IDS)
+    @pytest.mark.parametrize("skillset", _IMPLEMENTED_DICTS, ids=_IMPLEMENTED_IDS)
     def test_progress_advances_through_all_stages(self, skillset, tmp_path):
-        # Wire up a container — skillsets are now auto-discovered from
-        # BC modules via CodeSkillsetRepository, no JSON seeding needed.
+        # Copy pyproject.toml so CodeSkillsetRepository can discover packages
+        _write_pyproject(tmp_path)
+
         config = Config(
             repo_root=tmp_path,
             workspace_root=tmp_path / "clients",
@@ -195,22 +212,25 @@ class TestEntityRoundTrip:
     @pytest.mark.parametrize(
         "entity",
         [
-            make_project(),
-            make_decision(),
-            make_engagement(),
-            make_research(),
-            make_tour_stop(),
-            make_tour(),
-            make_skillset(),
-            PipelineStage(
-                order=1,
-                skill="test",
-                prerequisite_gate="a",
-                produces_gate="b",
-                description="Test",
+            pytest.param(make_project(), id="Project"),
+            pytest.param(make_decision(), id="DecisionEntry"),
+            pytest.param(make_engagement(), id="EngagementEntry"),
+            pytest.param(make_research(), id="ResearchTopic"),
+            pytest.param(make_tour_stop(), id="TourStop"),
+            pytest.param(make_tour(), id="TourManifest"),
+            pytest.param(make_skillset(), id="Skillset"),
+            pytest.param(make_prospectus(), id="Skillset-prospectus"),
+            pytest.param(
+                PipelineStage(
+                    order=1,
+                    skill="test",
+                    prerequisite_gate="a",
+                    produces_gate="b",
+                    description="Test",
+                ),
+                id="PipelineStage",
             ),
         ],
-        ids=lambda e: type(e).__name__,
     )
     def test_json_round_trip(self, entity):
         dumped = entity.model_dump(mode="json")
@@ -282,3 +302,67 @@ class TestPresenterContract:
         assert result.slug == slug
         assert result.skillset == skillset_name
         assert isinstance(result.sections, list)
+
+
+# ---------------------------------------------------------------------------
+# 5. Skillset discipline — field-level validation for all skillsets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.doctrine
+class TestSkillsetDiscipline:
+    """Every skillset (implemented or prospectus) must declare required fields."""
+
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
+    def test_has_name(self, skillset):
+        assert skillset["name"], "Skillset must have a non-empty name"
+
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
+    def test_has_display_name(self, skillset):
+        assert skillset["display_name"], "Skillset must have a non-empty display_name"
+
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
+    def test_has_description(self, skillset):
+        assert skillset["description"], "Skillset must have a non-empty description"
+
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
+    def test_name_is_kebab_case(self, skillset):
+        import re
+
+        assert re.match(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", skillset["name"]), (
+            f"Skillset name must be kebab-case: {skillset['name']}"
+        )
+
+    @pytest.mark.parametrize("skillset", _ALL_DICTS, ids=_ALL_IDS)
+    def test_unique_names(self, skillset):
+        """Each skillset name appears exactly once across all BCs."""
+        count = sum(1 for s in _ALL_DICTS if s["name"] == skillset["name"])
+        assert count == 1, f"Skillset name {skillset['name']!r} appears {count} times"
+
+
+@pytest.mark.doctrine
+class TestSkillsetRegistration:
+    """Every BC package with SKILLSETS is listed in pyproject.toml."""
+
+    def test_all_bc_packages_in_pyproject(self):
+        """Packages exporting SKILLSETS must appear in pyproject.toml packages."""
+        pyproject_path = _REPO_ROOT / "pyproject.toml"
+        registered = _read_pyproject_packages(pyproject_path)
+        bc_packages = {"wardley_mapping", "business_model_canvas"}
+        for pkg in bc_packages:
+            assert pkg in registered, (
+                f"BC package {pkg!r} not in pyproject.toml packages list"
+            )
+
+    def test_dynamic_discovery_finds_all_skillsets(self):
+        """CodeSkillsetRepository discovers the same skillsets as direct import."""
+        from bin.cli.infrastructure.code_skillset_repository import (
+            CodeSkillsetRepository,
+        )
+
+        repo = CodeSkillsetRepository(_REPO_ROOT)
+        discovered_names = {s.name for s in repo.list_all()}
+        expected_names = {s.name for s in _ALL_SKILLSETS}
+        assert discovered_names == expected_names, (
+            f"Discovery mismatch: found {discovered_names}, expected {expected_names}"
+        )

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -21,6 +21,7 @@ from .conftest import (
     make_engagement,
     make_engagement_entity,
     make_project,
+    make_prospectus,
     make_research,
     make_skillset,
     make_skillset_source,
@@ -65,24 +66,27 @@ class TestRoundTrip:
     @pytest.mark.parametrize(
         "entity",
         [
-            make_project(),
-            make_decision(),
-            make_engagement(),
-            make_research(),
-            make_tour_stop(),
-            make_tour(),
-            make_skillset(),
-            make_engagement_entity(),
-            make_skillset_source(),
-            PipelineStage(
-                order=1,
-                skill="wm-research",
-                prerequisite_gate="resources/index.md",
-                produces_gate="brief.agreed.md",
-                description="Kickoff",
+            pytest.param(make_project(), id="Project"),
+            pytest.param(make_decision(), id="DecisionEntry"),
+            pytest.param(make_engagement(), id="EngagementEntry"),
+            pytest.param(make_research(), id="ResearchTopic"),
+            pytest.param(make_tour_stop(), id="TourStop"),
+            pytest.param(make_tour(), id="TourManifest"),
+            pytest.param(make_skillset(), id="Skillset"),
+            pytest.param(make_prospectus(), id="Skillset-prospectus"),
+            pytest.param(make_engagement_entity(), id="Engagement"),
+            pytest.param(make_skillset_source(), id="SkillsetSource"),
+            pytest.param(
+                PipelineStage(
+                    order=1,
+                    skill="wm-research",
+                    prerequisite_gate="resources/index.md",
+                    produces_gate="brief.agreed.md",
+                    description="Kickoff",
+                ),
+                id="PipelineStage",
             ),
         ],
-        ids=lambda e: type(e).__name__,
     )
     def test_json_round_trip(self, entity):
         cls = type(entity)
@@ -110,6 +114,22 @@ class TestRoundTrip:
 # ---------------------------------------------------------------------------
 # Entity-specific semantics
 # ---------------------------------------------------------------------------
+
+
+class TestSkillsetImplementation:
+    """is_implemented reflects whether the pipeline has stages."""
+
+    def test_implemented_with_pipeline(self):
+        s = make_skillset()
+        assert s.is_implemented is True
+
+    def test_not_implemented_without_pipeline(self):
+        s = make_prospectus()
+        assert s.is_implemented is False
+
+    def test_empty_pipeline_is_not_implemented(self):
+        s = make_skillset(pipeline=[])
+        assert s.is_implemented is False
 
 
 class TestTourStopOrder:


### PR DESCRIPTION
## Summary

- Add descriptive fields to `Skillset` entity: `problem_domain`, `deliverables`, `value_proposition`, `classification`, `evidence`
- Default `pipeline` to `[]` so an empty-pipeline Skillset is a prospectus (unimplemented methodology)
- Add `is_implemented` property to distinguish implemented skillsets from prospectuses
- Replace hardcoded module list in `CodeSkillsetRepository` with dynamic discovery from pyproject.toml packages
- Add `SkillsetScaffold` infrastructure for creating stub BC packages with `__init__.py` and pyproject.toml registration
- Add `RegisterProspectusUseCase` and `UpdateProspectusUseCase` with CLI commands (`skillset add`, `skillset update`)
- Enrich `skillset list` and `skillset show` formatters with new fields and implementation status
- Add doctrine tests: field discipline, kebab-case naming, name uniqueness, dynamic discovery conformance

## Test plan

- [x] All 330 tests pass
- [x] All 79 doctrine tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `uv run practice skillset list` shows implemented skillsets
- [x] `uv run practice skillset add --name test-method --display-name "Test Method" --description "A test" --slug-pattern "test-{n}"` creates a prospectus
- [x] `uv run practice skillset show --name test-method` shows descriptive fields, 0 stages

Closes #79