### PR TITLE
Clean up test debt from frontmatter entity migration

### DIFF
--- a/bin/cli/infrastructure/pack_nudger.py
+++ b/bin/cli/infrastructure/pack_nudger.py
@@ -1,19 +1,16 @@
 """Check design-time packs for freshness and produce nudge strings.
 
-Discovers knowledge packs via ``FilesystemKnowledgePackRepository``
-and checks each for bytecode freshness. Returns human-readable nudge
-strings for any pack that is dirty or corrupt.
+Discovers knowledge packs via ``KnowledgePackRepository`` and checks
+each for bytecode freshness. Returns human-readable nudge strings for
+any pack that is dirty or corrupt.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from bin.cli.infrastructure.filesystem_knowledge_pack_repository import (
-    FilesystemKnowledgePackRepository,
-)
 from practice.entities import CompilationState
-from practice.repositories import FreshnessInspector
+from practice.repositories import FreshnessInspector, KnowledgePackRepository
 
 
 _STATE_LABELS = {
@@ -31,21 +28,19 @@ class FilesystemPackNudger:
         repo_root: Path,
         inspector: FreshnessInspector,
         skillset_bc_dirs: dict[str, Path] | None = None,
-        knowledge_packs: FilesystemKnowledgePackRepository | None = None,
+        knowledge_packs: KnowledgePackRepository | None = None,
     ) -> None:
+        if knowledge_packs is None:
+            raise TypeError("knowledge_packs is required")
         self._repo_root = repo_root
         self._inspector = inspector
         self._skillset_bc_dirs = skillset_bc_dirs or {}
         self._knowledge_packs = knowledge_packs
 
     def check(self, skillset_names: list[str] | None = None) -> list[str]:
-        if self._knowledge_packs is not None:
-            packs = [
-                (pack.name, path)
-                for pack, path in self._knowledge_packs.packs_with_paths()
-            ]
-        else:
-            packs = _discover_packs(self._repo_root)
+        packs = [
+            (pack.name, path) for pack, path in self._knowledge_packs.packs_with_paths()
+        ]
 
         nudges: list[str] = []
 
@@ -80,33 +75,3 @@ class FilesystemPackNudger:
             )
 
         return nudges
-
-
-def _discover_packs(repo_root: Path) -> list[tuple[str, Path]]:
-    """Find all version-controlled packs with manifest frontmatter.
-
-    Legacy fallback — used when no knowledge pack repository is injected.
-    """
-    from practice.frontmatter import parse_frontmatter
-
-    results: list[tuple[str, Path]] = []
-    search_roots = [repo_root / "docs", repo_root / "commons"]
-
-    personal = repo_root / "personal"
-    if personal.is_dir():
-        search_roots.append(personal)
-
-    partnerships = repo_root / "partnerships"
-    if partnerships.is_dir():
-        for child in sorted(partnerships.iterdir()):
-            if child.is_dir():
-                search_roots.append(child)
-
-    for search_root in search_roots:
-        if not search_root.is_dir():
-            continue
-        for index_md in search_root.rglob("index.md"):
-            fm = parse_frontmatter(index_md)
-            if "name" in fm and "purpose" in fm:
-                results.append((fm["name"], index_md.parent))
-    return results

--- a/src/practice/repositories.py
+++ b/src/practice/repositories.py
@@ -233,6 +233,10 @@ class KnowledgePackRepository(Protocol):
         """List all discovered knowledge packs."""
         ...
 
+    def packs_with_paths(self) -> list[tuple[KnowledgePack, Path]]:
+        """Return (pack, pack_root) pairs for all discovered packs."""
+        ...
+
 
 @runtime_checkable
 class EngagementRepository(Protocol):

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -439,11 +439,6 @@ class TestCliRegistrationProtocol:
 _NAME_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*$")
 
 
-def _parse_skill_frontmatter(skill_md_path: Path) -> dict:
-    """Delegate to the shared frontmatter parser."""
-    return parse_frontmatter(skill_md_path)
-
-
 def _load_skill_manifest(skill_md_path: Path) -> SkillManifest:
     """Parse and validate a SKILL.md into a SkillManifest entity."""
     fm = parse_frontmatter(skill_md_path)


### PR DESCRIPTION
Addresses all 8 items from #105:

1. **Delete `_discover_packs()`** — legacy fallback in pack_nudger.py, unreachable since DI always injects the repository
2. **Delete `_parse_skill_frontmatter()`** — dead code in test_conformance.py, replaced by `_load_skill_manifest()`
3. **FilesystemSkillManifestRepository tests** — get(), list_all(), source container scanning, silent-skip-on-validation-failure behavior
4. **FilesystemKnowledgePackRepository protocol tests** — get(), list_all() (the protocol methods that had zero coverage)
5. **Negative SkillManifest validation tests** — bad name format, underscore name, empty description, overlong description, invalid freedom level, missing metadata
6. **Trailing-newline boundary test** — documents YAML folded scalar edge case where 1024-char body + `\n` = 1025 chars exceeds max_length
7. **Fix protocol leak** — add `packs_with_paths()` to `KnowledgePackRepository` protocol; nudger now accepts the protocol type instead of concrete `FilesystemKnowledgePackRepository`
8. **Fix stale docstring** — `TestManifestFrontmatter` now correctly references PyYAML

Net: +22 test functions, -1 dead function, -1 dead helper, protocol leak closed.

Closes #105.